### PR TITLE
Check if the platform is macOS before setting TCP_KEEPIDLE

### DIFF
--- a/tools/MultiRelay.py
+++ b/tools/MultiRelay.py
@@ -140,7 +140,9 @@ def ConnectToTarget():
             s.setsockopt(SOL_SOCKET, SO_KEEPALIVE, 1)
             s.setsockopt(IPPROTO_TCP, TCP_KEEPCNT, 15)
             s.setsockopt(IPPROTO_TCP, TCP_KEEPINTVL, 5)
-            s.setsockopt(IPPROTO_TCP, TCP_KEEPIDLE, 5)
+            # macOS does not have TCP_KEEPIDLE
+            if sys.platform != 'darwin':
+                s.setsockopt(IPPROTO_TCP, TCP_KEEPIDLE, 5)
             s.connect(Host)  
             return s
         except:


### PR DESCRIPTION
**Problem**
On macOS hosts, the `TCP_KEEPIDLE` is not exported for python. Running `MultiRelay.py` on macOS hosts would crash when trying to connect to a target host as a result.

```
----------------------------------------
Exception happened during processing of request from ('x.x.x.x', xxxxx)
Traceback (most recent call last):
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/SocketServer.py", line 295, in _handle_request_noblock
    self.process_request(request, client_address)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/SocketServer.py", line 321, in process_request
    self.finish_request(request, client_address)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/SocketServer.py", line 334, in finish_request
    self.RequestHandlerClass(request, client_address, self)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/SocketServer.py", line 655, in __init__
    self.handle()
  File "tools/MultiRelay.py", line 255, in handle
    s = ConnectToTarget()
  File "tools/MultiRelay.py", line 148, in ConnectToTarget
    sys.exit(1)
SystemExit: 1
----------------------------------------
```

**Env Info**
```
» python -V
Python 2.7.10

» sw_vers -productVersion
10.12.1
```

**Proposed Fix**
Debugging this, I dumped the exception thrown [here](https://github.com/lgandx/Responder/blob/master/tools/MultiRelay.py#L146) and realized that the `TCP_KEEPIDLE` option was being set based on the exception message: `global name 'TCP_KEEPIDLE' is not defined`, but is not available from the `from socket import *` import on macOS.

```
----------------------------------------
global name 'TCP_KEEPIDLE' is not defined
----------------------------------------
```

In order to fix the problem (and still have it work fine on Linux hosts), I added a check to see if the platform is `darwin`, and just skip the `setsockopt` call for the `TCP_KEEPIDLE` option.