### PR TITLE
added `ip` commands in addition to ifconfig and netstat

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -229,9 +229,12 @@ class Settings:
                 
 		try:
 			NetworkCard = subprocess.check_output(["ifconfig", "-a"])
-		except subprocess.CalledProcessError as ex:
-			NetworkCard = "Error fetching Network Interfaces:", ex
-			pass
+		except:
+			try:
+				NetworkCard = subprocess.check_output(["ip", "address", "show"])
+			except subprocess.CalledProcessError as ex:
+				NetworkCard = "Error fetching Network Interfaces:", ex
+				pass
 		try:
 			DNS = subprocess.check_output(["cat", "/etc/resolv.conf"])
 		except subprocess.CalledProcessError as ex:
@@ -239,9 +242,12 @@ class Settings:
 			pass
 		try:
 			RoutingInfo = subprocess.check_output(["netstat", "-rn"])
-		except subprocess.CalledProcessError as ex:
-			RoutingInfo = "Error fetching Routing information:", ex
-			pass
+		except:
+			try:
+				RoutingInfo = subprocess.check_output(["ip", "route", "show"])
+			except subprocess.CalledProcessError as ex:
+				RoutingInfo = "Error fetching Routing information:", ex
+				pass
 
 		Message = "Current environment is:\nNetwork Config:\n%s\nDNS Settings:\n%s\nRouting info:\n%s\n\n"%(NetworkCard,DNS,RoutingInfo)
 		try:


### PR DESCRIPTION
Current build is failing on a new build of Kali2 as ifconfig and netstat commands appear to be removed:
```
Traceback (most recent call last):
  File "Responder.py", line 56, in <module>
    settings.Config.populate(options)
  File "/pentest/Responder/settings.py", line 247, in populate
    RoutingInfo = subprocess.check_output(["netstat", "-rn"])
  File "/usr/lib/python2.7/subprocess.py", line 212, in check_output
    process = Popen(stdout=PIPE, *popenargs, **kwargs)
  File "/usr/lib/python2.7/subprocess.py", line 390, in __init__
    errread, errwrite)
  File "/usr/lib/python2.7/subprocess.py", line 1024, in _execute_child
    raise child_exception
OSError: [Errno 2] No such file or directory
```
Added in additional processing for `ip` commands:
```
ip address show
ip route show
```
