### PR TITLE
Python 2.4, 2.5 compatibility. SSL and sqlite3 modules are not mandatory

### DIFF
--- a/Responder.py
+++ b/Responder.py
@@ -15,13 +15,18 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import optparse
-import ssl
 
 from SocketServer import TCPServer, UDPServer, ThreadingMixIn
 from threading import Thread
 from utils import *
 import struct
 banner()
+
+try:
+	import ssl
+except ImportError:
+	ssl = False
+	print color("[!] Module 'ssl' is unavailable. HTTPS is disabled")
 
 parser = optparse.OptionParser(usage='python %prog -I eth0 -w -r -f\nor:\npython %prog -I eth0 -wrf', version=settings.__version__, prog=sys.argv[0])
 parser.add_option('-A','--analyze',        action="store_true", help="Analyze mode. This option allows you to see NBT-NS, BROWSER, LLMNR requests without responding.", dest="Analyze", default=False)
@@ -35,7 +40,7 @@ parser.add_option('-r', '--wredir',        action="store_true", help="Enable ans
 parser.add_option('-d', '--NBTNSdomain',   action="store_true", help="Enable answers for netbios domain suffix queries. Answering to domain suffixes will likely break stuff on the network. Default: False", dest="NBTNSDomain", default=False)
 parser.add_option('-f','--fingerprint',    action="store_true", help="This option allows you to fingerprint a host that issued an NBT-NS or LLMNR query.", dest="Finger", default=False)
 parser.add_option('-w','--wpad',           action="store_true", help="Start the WPAD rogue proxy server. Default value is False", dest="WPAD_On_Off", default=False)
-parser.add_option('-u','--upstream-proxy', action="store",      help="Upstream HTTP proxy used by the rogue WPAD Proxy for outgoing requests (format: host:port)", dest="Upstream_Proxy", default=None)
+parser.add_option('-u','--upstream-proxy', action="store",      help="Upstream HTTP proxy used by the rogue WPAD Proxy for outgoing requests (format: host:port)", dest="Upstream_Proxy", default=False)
 parser.add_option('-F','--ForceWpadAuth',  action="store_true", help="Force NTLM/Basic authentication on wpad.dat file retrieval. This may cause a login prompt. Default: False", dest="Force_WPAD_Auth", default=False)
 
 parser.add_option('-P','--ProxyAuth',       action="store_true", help="Force NTLM (transparently)/Basic (prompt) authentication for the proxy. WPAD doesn't need to be ON. This option is highly effective when combined with -r. Default: False", dest="ProxyAuth_On_Off", default=False)
@@ -237,7 +242,7 @@ def main():
 			from servers.HTTP import HTTP
 			threads.append(Thread(target=serve_thread_tcp, args=('', 80, HTTP,)))
 
-		if settings.Config.SSL_On_Off:
+		if settings.Config.SSL_On_Off and ssl:
 			from servers.HTTP import HTTPS
 			threads.append(Thread(target=serve_thread_SSL, args=('', 443, HTTPS,)))
 

--- a/packets.py
+++ b/packets.py
@@ -22,7 +22,7 @@ from odict import OrderedDict
 from utils import HTTPCurrentDate, RespondWithIPAton
 
 # Packet class handling all packet generation (see odict.py).
-class Packet():
+class Packet:
 	fields = OrderedDict([
 		("data", ""),
 	])

--- a/servers/HTTP.py
+++ b/servers/HTTP.py
@@ -144,8 +144,10 @@ def ServeOPTIONS(data):
 	return False
 
 def ServeFile(Filename):
-	with open (Filename, "rb") as bk:
-		return bk.read()
+	bk = open(Filename, "rb")
+	data = bk.read()
+	bk.close()
+	return data
 
 def RespondWithFile(client, filename, dlname=None):
 	

--- a/servers/HTTP_Proxy.py
+++ b/servers/HTTP_Proxy.py
@@ -236,17 +236,17 @@ class HTTP_Proxy(BaseHTTPServer.BaseHTTPRequestHandler):
 			soc = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 
 		try:
-			if self._connect_to(self.path, soc):
-				self.wfile.write(self.protocol_version +" 200 Connection established\r\n")
-				self.wfile.write("Proxy-agent: %s\r\n" % self.version_string())
-				self.wfile.write("\r\n")
-				try:
-					self._read_write(soc, 300)
-				except:
-					pass
-		except:
-			pass
-
+			try:
+				if self._connect_to(self.path, soc):
+					self.wfile.write(self.protocol_version +" 200 Connection established\r\n")
+					self.wfile.write("Proxy-agent: %s\r\n" % self.version_string())
+					self.wfile.write("\r\n")
+					try:
+						self._read_write(soc, 300)
+					except:
+						pass
+			except:
+				pass
 		finally:
 			soc.close()
 			self.connection.close()
@@ -266,36 +266,36 @@ class HTTP_Proxy(BaseHTTPServer.BaseHTTPRequestHandler):
 			soc = self.socket_proxy(socket.AF_INET, socket.SOCK_STREAM)
 		else:
 			soc = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-
 		try:
-			URL_Unparse = urlparse.urlunparse(('', '', path, params, query, ''))
+			try:
+				URL_Unparse = urlparse.urlunparse(('', '', path, params, query, ''))
 
-			if self._connect_to(netloc, soc):
-				soc.send("%s %s %s\r\n" % (self.command, URL_Unparse, self.request_version))
+				if self._connect_to(netloc, soc):
+					soc.send("%s %s %s\r\n" % (self.command, URL_Unparse, self.request_version))
 
-				Cookie = self.headers['Cookie'] if "Cookie" in self.headers else ''
+					Cookie = self.headers.get('Cookie', '')
 
-				if settings.Config.Verbose:
-					print text("[PROXY] Client        : %s" % color(self.client_address[0], 3))
-					print text("[PROXY] Requested URL : %s" % color(self.path, 3))
-					print text("[PROXY] Cookie        : %s" % Cookie)
+					if settings.Config.Verbose:
+						print text("[PROXY] Client        : %s" % color(self.client_address[0], 3))
+						print text("[PROXY] Requested URL : %s" % color(self.path, 3))
+						print text("[PROXY] Cookie        : %s" % Cookie)
 
-				self.headers['Connection'] = 'close'
-				del self.headers['Proxy-Connection']
-				del self.headers['If-Range']
-				del self.headers['Range']
-				
-				for k, v in self.headers.items():
-					soc.send("%s: %s\r\n" % (k.title(), v))
-				soc.send("\r\n")
+					self.headers['Connection'] = 'close'
+					del self.headers['Proxy-Connection']
+					del self.headers['If-Range']
+					del self.headers['Range']
 
-				try:
-					self._read_write(soc, netloc)
-				except:
-					pass
+					for k, v in self.headers.items():
+						soc.send("%s: %s\r\n" % (k.title(), v))
+					soc.send("\r\n")
 
-		except:
-			pass
+					try:
+						self._read_write(soc, netloc)
+					except:
+						pass
+
+			except:
+				pass
 
 		finally:
 			soc.close()

--- a/tools/DHCP.py
+++ b/tools/DHCP.py
@@ -222,7 +222,10 @@ class DHCPInformACK(Packet):
 		self.fields["Op252Len"] = struct.pack(">b",len(str(self.fields["Op252Str"])))
 
 def SpoofIP(Spoof):
-	return ROUTERIP if Spoof else Responder_IP
+	if Spoof:
+		return ROUTERIP
+	else:
+		return Responder_IP
 
 def RespondToThisIP(ClientIp):
 	if ClientIp.startswith('127.0.0.'):

--- a/tools/MultiRelay/RelayMultiPackets.py
+++ b/tools/MultiRelay/RelayMultiPackets.py
@@ -20,7 +20,7 @@ from odict import OrderedDict
 import datetime
 from base64 import b64decode, b64encode
 
-class Packet():
+class Packet:
     fields = OrderedDict([
         ("data", ""),
     ])

--- a/tools/MultiRelay/creddump/framework/win32/hashdump.py
+++ b/tools/MultiRelay/creddump/framework/win32/hashdump.py
@@ -176,11 +176,20 @@ def get_user_hashes(user_key, hbootkey):
 
     hash_offset = unpack("<L", V[0x9c:0x9c+4])[0] + 0xCC
 
-    lm_exists = True if unpack("<L", V[0x9c+4:0x9c+8])[0] == 20 else False
-    nt_exists = True if unpack("<L", V[0x9c+16:0x9c+20])[0] == 20 else False
+    lm_exists = unpack("<L", V[0x9c+4:0x9c+8])[0] == 20
+    nt_exists = unpack("<L", V[0x9c+16:0x9c+20])[0] == 20
 
-    enc_lm_hash = V[hash_offset+4:hash_offset+20] if lm_exists else ""
-    enc_nt_hash = V[hash_offset+(24 if lm_exists else 8):hash_offset+(24 if lm_exists else 8)+16] if nt_exists else ""
+    if lm_exists:
+        enc_lm_hash = V[hash_offset+4:hash_offset+20]
+        lm_hash_offset = 24
+    else:
+        enc_lm_hash = ""
+        lm_hash_offset = 8
+
+    if nt_exists:
+        enc_nt_hash = V[hash_offset+lm_hash_offset:hash_offset+lm_hash_offset+16]
+    else:
+        enc_nt_hash = ""
 
     return decrypt_hashes(rid, enc_lm_hash, enc_nt_hash, hbootkey)
 

--- a/tools/RunFinger.py
+++ b/tools/RunFinger.py
@@ -38,7 +38,7 @@ Timeout = 2
 Host = options.TARGET
 Grep = options.Grep
 
-class Packet():
+class Packet:
     fields = OrderedDict([
     ])
     def __init__(self, **kw):

--- a/tools/SMBFinger/Finger.py
+++ b/tools/SMBFinger/Finger.py
@@ -20,7 +20,7 @@ from odict import OrderedDict
 
 __version__ = "0.3"
 Timeout = 0.5
-class Packet():
+class Packet:
     fields = OrderedDict([
     ])
     def __init__(self, **kw):
@@ -220,8 +220,9 @@ def ShowResults(Host):
        Signing, OsVer, LanManClient = SmbFinger(Host)
        enabled  = color("SMB signing is mandatory. Choose another target", 1, 1)
        disabled = color("SMB signing: False", 2, 1)
+       disabled_enabled = (disabled, enabled)
        print color("Retrieving information for %s..."%Host[0], 8, 1)
-       print enabled if Signing else disabled
+       print disabled_enabled[Signing]
        print color("Os version: '%s'"%(OsVer), 8, 3)
        print color("Hostname: '%s'\nPart of the '%s' domain"%(Hostname, DomainJoined), 8, 3)
     except:


### PR DESCRIPTION
Pull request reintroduces compatibility with previous versions of python (python 2.4 and python 2.5). Such versions can still be found during pentests, and responder in it's essence should start inside local network.

Pull request removes python2.6+ syntax like:

- With statement
- try-except-finally
- ternary operator, etc.

Also ssl and sqlite3 modules are not mandatory. It will only disable HTTPS and sqlite logging in favor of files.