### PR TITLE
Fixing HTTP header issue

### DIFF
--- a/Responder.py
+++ b/Responder.py
@@ -239,7 +239,7 @@ def main():
 
 		if settings.Config.SSL_On_Off:
 			from servers.HTTP import HTTPS
-			threads.append(Thread(target=serve_thread_SSL, args=('', 443, HTTPS,)))
+			threads.append(Thread(target=serve_thread_SSL, args=('', 443, HTTP,)))
 
 		if settings.Config.WPAD_On_Off:
 			from servers.HTTP_Proxy import HTTP_Proxy

--- a/servers/HTTP.py
+++ b/servers/HTTP.py
@@ -309,31 +309,4 @@ class HTTP(BaseRequestHandler):
 		
 		except socket.error:
 			pass
-
-"""
-# HTTPS Server class
-class HTTPS(BaseRequestHandler):
-	#def setup(self):
-	#	self.exchange = self.request
-	#	self.rfile = socket._fileobject(self.request, "rb", self.rbufsize)
-	#	self.wfile = socket._fileobject(self.request, "wb", self.wbufsize)
-
-	#def handle(self):
-	#	try:
-     #                   Challenge = RandomChallenge()
-			data = self.exchange.recv(8092)
-			self.exchange.settimeout(0.5)
-			Buffer = WpadCustom(data,self.client_address[0])
-				
-			if Buffer and settings.Config.Force_WPAD_Auth == False:
-				self.exchange.send(Buffer)
-				if settings.Config.Verbose:
-					print text("[HTTPS] WPAD (no auth) file sent to %s" % self.client_address[0])
-
-			else:
-				Buffer = PacketSequence(data,self.client_address[0], Challenge)
-				self.exchange.send(Buffer)
-		except:
-			pass
-
-"""
+			

--- a/servers/HTTP.py
+++ b/servers/HTTP.py
@@ -310,16 +310,17 @@ class HTTP(BaseRequestHandler):
 		except socket.error:
 			pass
 
+"""
 # HTTPS Server class
-class HTTPS(StreamRequestHandler):
-	def setup(self):
-		self.exchange = self.request
-		self.rfile = socket._fileobject(self.request, "rb", self.rbufsize)
-		self.wfile = socket._fileobject(self.request, "wb", self.wbufsize)
+class HTTPS(BaseRequestHandler):
+	#def setup(self):
+	#	self.exchange = self.request
+	#	self.rfile = socket._fileobject(self.request, "rb", self.rbufsize)
+	#	self.wfile = socket._fileobject(self.request, "wb", self.wbufsize)
 
-	def handle(self):
-		try:
-                        Challenge = RandomChallenge()
+	#def handle(self):
+	#	try:
+     #                   Challenge = RandomChallenge()
 			data = self.exchange.recv(8092)
 			self.exchange.settimeout(0.5)
 			Buffer = WpadCustom(data,self.client_address[0])
@@ -335,3 +336,4 @@ class HTTPS(StreamRequestHandler):
 		except:
 			pass
 
+"""


### PR DESCRIPTION
1.  	0e3e6f9
The HTTP and HTTPS modules were crashing when using Responder in a real-world scenario. It turned out that the above mentioned modules recv function were implemented in the good hopes that a simple call to socket.recv(N) will actually receive N bytes of data (or the full header). However this is not always the case.

> http://man7.org/linux/man-pages/man2/recv.2.html 
> The receive calls normally return any data available, up to the requested amount, rather than waiting for receipt of the full amount requested.

2.  	2c32704
As the HTTP class is technically the same as the HTTPS class (since the SSL wrapping happens in Responder.py). If you decide to keep it the original way, please share a reason I'm interested.
