### PR TITLE
Pass Challenge value to the LDAP parsing function

### DIFF
--- a/servers/LDAP.py
+++ b/servers/LDAP.py
@@ -27,7 +27,7 @@ def ParseSearch(data):
 	elif re.search(r'(?i)(objectClass0*.*supportedSASLMechanisms)', data):
 		return str(LDAPSearchSupportedMechanismsPacket(MessageIDASNStr=data[8:9],MessageIDASN2Str=data[8:9]))
 
-def ParseLDAPHash(data, client):
+def ParseLDAPHash(data, client, Challenge):
 	SSPIStart = data[42:]
 	LMhashLen = struct.unpack('<H',data[54:56])[0]
 
@@ -67,7 +67,7 @@ def ParseNTLM(data,client, Challenge):
 		NTLMChall.calculate()
 		return str(NTLMChall)
 	elif re.search('(NTLMSSP\x00\x03\x00\x00\x00)', data):
-		ParseLDAPHash(data,client)
+		ParseLDAPHash(data, client, Challenge)
 
 def ParseLDAPPacket(data, client, Challenge):
 	if data[1:2] == '\x84':


### PR DESCRIPTION
Recent changes that support random challenges missed one case where the `Challenge` value needed to passed in to the `ParseLDAPHash` function. This PR contains a 2-line changes that fixes this and prevents the program from failing in this case.