### PR TITLE
Fixed space typo in FindSMB2UPTime.py

### DIFF
--- a/tools/FindSMB2UPTime.py
+++ b/tools/FindSMB2UPTime.py
@@ -39,7 +39,7 @@ def IsDCVuln(t):
     if t[0] < Date:
        print "System is up since:", t[1]
        print "This system may be vulnerable to MS17-010"
-     print "DC is up since:", t[1]
+    print "DC is up since:", t[1]
 
 
 def run(host):


### PR DESCRIPTION
Hey,

I just noticed there was a space typo in the FindSMB2UPTime.py script.
This was the error:

`  File "tools/FindSMB2UPTime.py", line 42`
`    print "DC is up since:", t[1]`
`IndentationError: unindent does not match any outer indentation level`


It looks like it was introduced in the commit 5859c31e8ecf35c5b12ac653e8ab793bc9270604 on 28 Jun.

Best regards.