### PR TITLE
Fixed some small typos in MS17-010 output

### DIFF
--- a/tools/RunFinger.py
+++ b/tools/RunFinger.py
@@ -228,9 +228,9 @@ def ShowResults(Host):
        print "Retrieving information for %s..."%Host[0]
        print "SMB signing:", Signing
        print "Null Sessions Allowed:", NullSess
-       print "Vulnerable to MS10-010:", Ms17010
+       print "Vulnerable to MS17-010:", Ms17010
        print "Server Time:", Time[1]
-       print "Os version: '%s'\nLanman Client: '%s'"%(OsVer, LanManClient)
+       print "OS version: '%s'\nLanman Client: '%s'"%(OsVer, LanManClient)
        print "Machine Hostname: '%s'\nThis machine is part of the '%s' domain\n"%(Hostname, DomainJoined)
     except:
        pass


### PR DESCRIPTION
Hey there,

This change just fixes the MS17-010 check. There's a small typo that outputs the result as MS10-010. I also changed "Os" to "OS" a couple of lines down.