### PR TITLE
Fix version number in settings.py

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -20,7 +20,7 @@ import subprocess
 
 from utils import *
 
-__version__ = 'Responder 2.3.3.6'
+__version__ = 'Responder 2.3.3.9'
 
 class Settings:
 	


### PR DESCRIPTION
Kali has [a patch for this](http://git.kali.org/gitweb/?p=packages/responder.git;a=blobdiff;f=debian/patches/fix-version.patch;h=91179a7ec2b3d3ce05399e05d28b4bbb6fbc65df;hp=b7ba95264ab306773d4d873c645c923581c75a78;hb=14eb8501d0ee1a074589be252d68f81e31753674;hpb=c1a60f7b54bce6ebd48fbd8e3f42b79073d18dc0) too