### PR TITLE
Fix multi HTTP responses

### DIFF
--- a/servers/HTTP.py
+++ b/servers/HTTP.py
@@ -294,6 +294,8 @@ class HTTP(BaseRequestHandler):
 								line = line.strip()
 								remaining = int(line.split(':')[1].strip()) - len(data)
 			
+				if data == "":
+					break
 				#now the data variable has the full request
 				Buffer = WpadCustom(data, self.client_address[0])
 


### PR DESCRIPTION
If the client keeps the connection open after receiving the HTTP response, the response will be sent several times. Proof is that in the output we can see many:
> [HTTP] Sending NTLM authentication request to xxxx

This PR fixes this.
Thanks to @skelsec who wrote this part of the code for the fix suggestion!