### PR TITLE
FindSMB2UPTime: properly deal with servers not disclosing their boot time

### DIFF
--- a/tools/FindSMB2UPTime.py
+++ b/tools/FindSMB2UPTime.py
@@ -25,12 +25,18 @@ from packets import SMBHeaderReq, SMB2NegoReq, SMB2NegoDataReq
 
 def GetBootTime(data):
     Filetime = int(struct.unpack('<q',data)[0])
+    if Filetime == 0:  # server may not disclose this info
+        return 0, "Unknown"
     t = divmod(Filetime - 116444736000000000, 10000000)
     time = datetime.datetime.fromtimestamp(t[0])
     return time, time.strftime('%Y-%m-%d %H:%M:%S')
 
 
 def IsDCVuln(t, host):
+    if t[0] == 0:
+        print "Server", host[0], "did not disclose its boot time"
+        return
+    
     Date = datetime.datetime(2014, 11, 17, 0, 30)
     if t[0] < Date:
        print "System is up since:", t[1]


### PR DESCRIPTION
I've encountered cases where a server doesn't disclose its boot time (the ServerStartTime field is all zeros).

In this case, the current FindSMB2UPTime returns nothing (since `time.strftime('%Y-%m-%d %H:%M:%S')` triggers an exception for dates before 1900, and 0 means Windows Epoch in 1601).

With this patch, this case is properly handled. For example:
```
# python FindSMB2UPTime.py x.x.x.x/24
Server x.x.x.a did not disclose its boot time
Server x.x.x.b doesn't support SMBv2
Server x.x.x.c is up since: 2019-01-25 15:57:18
```