### PR TITLE
Fix socket timeout on HTTP POST requests

### DIFF
--- a/servers/HTTP.py
+++ b/servers/HTTP.py
@@ -278,21 +278,20 @@ class HTTP(BaseRequestHandler):
 						break
 					data += buff
 					remaining -= len(buff)
-					if remaining <= 0:
-						break
 					#check if we recieved the full header
 					if data.find('\r\n\r\n') != -1: 
 						#we did, now to check if there was anything else in the request besides the header
 						if data.find('Content-Length') == -1:
 							#request contains only header
 							break
-					else:
-						#searching for that content-length field in the header
-						for line in data.split('\r\n'):
-							if line.find('Content-Length') != -1:
-								line = line.strip()
-								remaining = int(line.split(':')[1].strip()) - len(data)
-			
+						else:
+							#searching for that content-length field in the header
+							for line in data.split('\r\n'):
+								if line.find('Content-Length') != -1:
+									line = line.strip()
+									remaining = int(line.split(':')[1].strip()) - len(data)
+					if remaining <= 0:
+						break
 				if data == "":
 					break
 				#now the data variable has the full request


### PR DESCRIPTION
Remaining size should be checked at the end of the loop, the current implementation hang when POST request Content-Lenght is 0.
We want to check for Content-Length header only if we received full header.
