### PR TITLE
IPv6 check in LLMNR

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ Supports NTLMv1, NTLMv2 hashes with Extended Security NTLMSSP by default. Succes
 
 In order to redirect SQL Authentication to this tool, you will need to set the option -r (NBT-NS queries for SQL Server lookup are using the Workstation Service name suffix) for systems older than windows Vista (LLMNR will be used for Vista and higher). This server supports NTLMv1, LMv2 hashes. This functionality was successfully tested on Windows SQL Server 2005 & 2008.
 
+- Built-in RDP Auth server.
+
+In order to redirect RDP Authentication to this tool, you will need to set the option -r (NBT-NS queries for RDP Server lookup are using the Workstation Service name suffix) for systems older than windows Vista (LLMNR will be used for Vista and higher). This server supports NTLMv1, NTLMv2 hashes. This rogue authentication server has been successfully tested on Windows RDP clients ranging from Windows 7  to Windows 10 1903.
+
 - Built-in HTTP Auth server.
 
 In order to redirect HTTP Authentication to this tool, you will need to set the option -r for Windows version older than Vista (NBT-NS queries for HTTP server lookup are sent using the Workstation Service name suffix). For Vista and higher, LLMNR will be used. This server supports NTLMv1, NTLMv2 hashes *and* Basic Authentication. This server was successfully tested on IE 6 to IE 10, Firefox, Chrome, Safari.

--- a/poisoners/LLMNR.py
+++ b/poisoners/LLMNR.py
@@ -36,7 +36,7 @@ def IsICMPRedirectPlausible(IP):
 		elif ip[0] == 'nameserver':
 			dnsip.extend(ip[1:])
 	for x in dnsip:
-		if x != "127.0.0.1" and IsOnTheSameSubnet(x,IP) is False:
+		if x != "127.0.0.1" and (":" not in x) and IsOnTheSameSubnet(x,IP) is False:
 			print color("[Analyze mode: ICMP] You can ICMP Redirect on this network.", 5)
 			print color("[Analyze mode: ICMP] This workstation (%s) is not on the same subnet than the DNS server (%s)." % (IP, x), 5)
 			print color("[Analyze mode: ICMP] Use `python tools/Icmp-Redirect.py` for more details.", 5)


### PR DESCRIPTION
I've had some ipv6 dns configured in my `/etc/resolv.conf`. Responder wasn't able to work with ipv6 so here is a quick fix
#20 