### PR TITLE
Syntax warning on literal semantics

### DIFF
--- a/tools/RunFingerPackets.py
+++ b/tools/RunFingerPackets.py
@@ -11,7 +11,7 @@ else:
 
 def StructWithLenPython2or3(endian,data):
     #Python2...
-    if PY2OR3 is "PY2":
+    if PY2OR3 == "PY2":
         return struct.pack(endian, data)
     #Python3...
     else:


### PR DESCRIPTION
/usr/share/responder/tools/RunFingerPackets.py:14: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if PY2OR3 is "PY2":