### PR TITLE
Correct Analyze log filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ All hashes are printed to stdout and dumped in an unique file John Jumbo complia
 Log files are located in the "logs/" folder. Hashes will be logged and printed only once per user per hash type, unless you are using the Verbose mode (-v).
 
 - Responder will log all its activity to Responder-Session.log
-- Analyze mode will be logged to Analyze-Session.log
+- Analyze mode will be logged to Analyzer-Session.log
 - Poisoning will be logged to Poisoners-Session.log
 
 Additionally, all captured hashed are logged into an SQLite database which you can configure in Responder.conf


### PR DESCRIPTION
The default filename for Analyze logs is Analyzer-Session.log, not
Analyze-Session.log.