### PR TITLE
Updated the README and Responder help flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,51 +125,48 @@ Running the tool:
 
 Typical Usage Example:
 
-    ./Responder.py -I eth0 -rPv
+    ./Responder.py -I eth0 -Pv
 
 Options:
-
-	  --version             show program's version number and exit
-	  -h, --help            show this help message and exit
-	  -A, --analyze         Analyze mode. This option allows you to see NBT-NS,
+    --version             show program's version number and exit
+    -h, --help            show this help message and exit
+    -A, --analyze         Analyze mode. This option allows you to see NBT-NS,
                         BROWSER, LLMNR requests without responding.
-	  -I eth0, --interface=eth0
+    -I eth0, --interface=eth0
                         Network interface to use, you can use 'ALL' as a
                         wildcard for all interfaces
-	  -i 10.0.0.21, --ip=10.0.0.21
+    -i 10.0.0.21, --ip=10.0.0.21
                         Local IP to use (only for OSX)
-	  -6 2002:c0a8:f7:1:3ba8:aceb:b1a9:81ed, --externalip6=2002:c0a8:f7:1:3ba8:aceb:b1a9:81ed
+    -6 2002:c0a8:f7:1:3ba8:aceb:b1a9:81ed, --externalip6=2002:c0a8:f7:1:3ba8:aceb:b1a9:81ed
                         Poison all requests with another IPv6 address than
                         Responder's one.
-	  -e 10.0.0.22, --externalip=10.0.0.22
+    -e 10.0.0.22, --externalip=10.0.0.22
                         Poison all requests with another IP address than
                         Responder's one.
-	  -b, --basic           Return a Basic HTTP authentication. Default: NTLM
-	  -r, --wredir          Enable answers for netbios wredir suffix queries.
-                        Answering to wredir will likely break stuff on the
-                        network. Default: False
-	  -d, --DHCP            Enable answers for DHCP broadcast requests. This
+    -b, --basic           Return a Basic HTTP authentication. Default: NTLM
+    -d, --DHCP            Enable answers for DHCP broadcast requests. This
                         option will inject a WPAD server in the DHCP response.
                         Default: False
-	  -D, --DHCP-DNS        This option will inject a DNS server in the DHCP
+    -D, --DHCP-DNS        This option will inject a DNS server in the DHCP
                         response, otherwise a WPAD server will be added.
                         Default: False
-	  -w, --wpad            Start the WPAD rogue proxy server. Default value is
+    -w, --wpad            Start the WPAD rogue proxy server. Default value is
                         False
-	  -u UPSTREAM_PROXY, --upstream-proxy=UPSTREAM_PROXY
+    -u UPSTREAM_PROXY, --upstream-proxy=UPSTREAM_PROXY
                         Upstream HTTP proxy used by the rogue WPAD Proxy for
                         outgoing requests (format: host:port)
-	  -F, --ForceWpadAuth   Force NTLM/Basic authentication on wpad.dat file
+    -F, --ForceWpadAuth   Force NTLM/Basic authentication on wpad.dat file
                         retrieval. This may cause a login prompt. Default:
                         False
-	  -P, --ProxyAuth       Force NTLM (transparently)/Basic (prompt)
+    -P, --ProxyAuth       Force NTLM (transparently)/Basic (prompt)
                         authentication for the proxy. WPAD doesn't need to be
                         ON. This option is highly effective when combined with
                         -r. Default: False
-	  --lm                  Force LM hashing downgrade for Windows XP/2003 and
+    --lm                  Force LM hashing downgrade for Windows XP/2003 and
                         earlier. Default: False
-	  --disable-ess         Force ESS downgrade. Default: False
-	  -v, --verbose         Increase verbosity.
+    --disable-ess         Force ESS downgrade. Default: False
+    -v, --verbose         Increase verbosity.
+
 
 	
 

--- a/Responder.py
+++ b/Responder.py
@@ -25,7 +25,7 @@ from utils import *
 import struct
 banner()
 
-parser = optparse.OptionParser(usage='python %prog -I eth0 -w -r -f\nor:\npython %prog -I eth0 -wrf', version=settings.__version__, prog=sys.argv[0])
+parser = optparse.OptionParser(usage='python %prog -I eth0 -w -d\nor:\npython %prog -I eth0 -wd', version=settings.__version__, prog=sys.argv[0])
 parser.add_option('-A','--analyze',        action="store_true", help="Analyze mode. This option allows you to see NBT-NS, BROWSER, LLMNR requests without responding.", dest="Analyze", default=False)
 parser.add_option('-I','--interface',      action="store",      help="Network interface to use, you can use 'ALL' as a wildcard for all interfaces", dest="Interface", metavar="eth0", default=None)
 parser.add_option('-i','--ip',             action="store",      help="Local IP to use \033[1m\033[31m(only for OSX)\033[0m", dest="OURIP", metavar="10.0.0.21", default=None)


### PR DESCRIPTION
New version of Responder does not have the -r flag anymore. I updated the README and the --help flags to reflect that. 