### PR TITLE
DE-RPC server status not correct

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -509,7 +509,7 @@ def StartupMessage():
 	print('    %-27s' % "DNS server" + (enabled if settings.Config.DNS_On_Off else disabled))
 	print('    %-27s' % "LDAP server" + (enabled if settings.Config.LDAP_On_Off else disabled))
 	print('    %-27s' % "RDP server" + (enabled if settings.Config.RDP_On_Off else disabled))
-	print('    %-27s' % "DCE-RPC server" + (enabled if settings.Config.RDP_On_Off else disabled))
+	print('    %-27s' % "DCE-RPC server" + (enabled if settings.Config.DCERPC_On_Off else disabled))
 	print('    %-27s' % "WinRM server" + (enabled if settings.Config.WinRM_On_Off else disabled))
 	print('')
 


### PR DESCRIPTION
Line 512 should read:
print(' %-27s' % "DCE-RPC server" + (enabled if settings.Config.DCERPC_On_Off else disabled))

Instead of:
print(' %-27s' % "DCE-RPC server" + (enabled if settings.Config.RDP_On_Off else disabled))