### PR TITLE
MutableMapping was moved to collections.abc

### DIFF
--- a/odict.py
+++ b/odict.py
@@ -1,9 +1,12 @@
 import sys
 try:
-	from UserDict import DictMixin
+    from UserDict import DictMixin
 except ImportError:
-	from collections import UserDict
-	from collections import MutableMapping as DictMixin
+    from collections import UserDict
+    try:
+        from collections import MutableMapping as DictMixin
+    except ImportError:
+        from collections.abc import MutableMapping as DictMixin
 
 class OrderedDict(dict, DictMixin):
 


### PR DESCRIPTION
and was removed from collections in newer versions of python
this change works in python 3.10.2 on manjaro linux