### PR TITLE
Fix double logging of first hash/cleartext when CaptureMultipleHashFromSameHost = On

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -337,16 +337,10 @@ def SaveToDb(result):
 	logfile = os.path.join(settings.Config.ResponderPATH, 'logs', fname)
 
 	if not count:
-		with open(logfile,"a") as outf:
-			if len(result['cleartext']):  # If we obtained cleartext credentials, write them to file
-				outf.write('%s:%s\n' % (result['user'].encode('utf8', 'replace'), result['cleartext'].encode('utf8', 'replace')))
-			else:  # Otherwise, write JtR-style hash string to file
-				outf.write(result['fullhash'] + '\n')#.encode('utf8', 'replace') + '\n')
-
 		cursor.execute("INSERT INTO responder VALUES(datetime('now'), ?, ?, ?, ?, ?, ?, ?, ?)", (result['module'], result['type'], result['client'], result['hostname'], result['user'], result['cleartext'], result['hash'], result['fullhash']))
 		cursor.commit()
 
-	if settings.Config.CaptureMultipleHashFromSameHost:
+	if not count or settings.Config.CaptureMultipleHashFromSameHost:
 		with open(logfile,"a") as outf:
 			if len(result['cleartext']):  # If we obtained cleartext credentials, write them to file
 				outf.write('%s:%s\n' % (result['user'].encode('utf8', 'replace'), result['cleartext'].encode('utf8', 'replace')))


### PR DESCRIPTION
If `CaptureMultipleHashFromSameHost = On` (the default), then Responder would log the first captured hash/cleartext twice for each unique `(<module>, <type>, <client>, <user> [, <cleartext>])` tuple.