### PR TITLE
Extend --disable-ess to HTTP

### DIFF
--- a/packets.py
+++ b/packets.py
@@ -359,7 +359,7 @@ class NTLM_Challenge(Packet):
 		("TargetNameLen",    "\x06\x00"),
 		("TargetNameMaxLen", "\x06\x00"),
 		("TargetNameOffset", "\x38\x00\x00\x00"),
-		("NegoFlags",        "\x05\x02\x89\xa2"),
+		("NegoFlags",        "\x05\x02\x81\xa2" if settings.Config.NOESS_On_Off else "\x05\x02\x89\xa2"),
 		("ServerChallenge",  ""),
 		("Reserved",         "\x00\x00\x00\x00\x00\x00\x00\x00"),
 		("TargetInfoLen",    "\x7e\x00"),


### PR DESCRIPTION
Hi !

@hackndo's great PR for disabling Extended Session Security (ESS) in NTLMv1 (https://github.com/lgandx/Responder/pull/163) was only implemented in SMB & LDAP.

This PR also implements it in HTTP. I was able to confirm successful downgrade on the HTTP server, allowing cracking of the response on crack.sh.

Looking at `packets.py`, the downgrade has also not been implemented for MSSQL, RPC, and RDP. I have not implemented it on these servers as I don't know of potential side effects and cannot test them as of now.

Cheers !