### PR TITLE
Implement SNMPv3 support

### DIFF
--- a/servers/SNMP.py
+++ b/servers/SNMP.py
@@ -15,14 +15,13 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from utils import *
+from binascii import hexlify
+from pyasn1.codec.ber.decoder import decode
 
 if settings.Config.PY2OR3 == "PY3":
     from socketserver import BaseRequestHandler
 else:
     from SocketServer import BaseRequestHandler
-
-from pyasn1.codec.der.decoder import decode
-
 
 class SNMP(BaseRequestHandler):
     def handle(self):
@@ -31,20 +30,33 @@ class SNMP(BaseRequestHandler):
 
         snmp_version = int(received_record['field-0'])
 
-        if snmp_version > 1:
-            # TODO: Add support for SNMPv3 (which will have a field-0 value of 2)
-            print(text("[SNMP] Unsupported SNMPv3 request received from %s" % self.client_address[0].replace("::ffff:","")))
-            return
+        if snmp_version == 3:
+            full_snmp_msg = hexlify(data).decode('utf-8')
+            received_record_inner, _ = decode(received_record['field-2'])
+            snmp_user = str(received_record_inner['field-3'])
+            engine_id = hexlify(received_record_inner['field-0']._value).decode('utf-8')
+            auth_params = hexlify(received_record_inner['field-4']._value).decode('utf-8')
 
-        community_string = str(received_record['field-1'])
 
-        SaveToDb(
-            {
+            SaveToDb({
                 "module": "SNMP",
-                "type": "Cleartext",
-                "client": self.client_address[0],
-                "user": community_string,
-                "cleartext": community_string,
-                "fullhash": community_string,
-            }
-        )
+                "type": "SNMPv3",
+                "client" : self.client_address[0],
+                "user": snmp_user,
+                "hash": auth_params,
+                "fullhash": "{}:{}:{}:{}".format(snmp_user, full_snmp_msg, engine_id, auth_params)
+            })
+        else:
+            community_string = str(received_record['field-1'])
+            snmp_version = '1' if snmp_version == 0 else '2c'
+
+            SaveToDb(
+                {
+                    "module": "SNMP",
+                    "type": "Cleartext SNMPv{}".format(snmp_version),
+                    "client": self.client_address[0],
+                    "user": community_string,
+                    "cleartext": community_string,
+                    "fullhash": community_string,
+                }
+            )


### PR DESCRIPTION
It was a great addition in #218 to support SNMP (https://zxsecurity.co.nz/research/insights/run-zero-credentials-capture/ awesome work!). This PR implements the support for SNMPv3 that was still outstanding.

This is the current output for SNMPv3, SNMPv1 and SNMPv2c:
![image](https://user-images.githubusercontent.com/66413174/202765013-cf8af328-d3a0-44af-aed0-241edbf7699e.png)

The output for SNMPv3 hash can be formatted easily for later cracking, for example with Hashcat. There is a [gist](https://gist.github.com/lowSoA/267538e0c2b82ea0281ba7ba9f01182a) which eases this process (with an included hash example from this PR).

**Note:** as in the original PR #218, `pyasn1` is required. Tested with `pyasn1==0.4.8`  in case it can be added to `requirements.txt`.