### PR TITLE
Allowing IPv6 addresses in RespondTo and DontRespondTo 

### DIFF
--- a/Responder.conf
+++ b/Responder.conf
@@ -47,6 +47,7 @@ RespondTo =
 RespondToName = 
 
 ; Specific IP Addresses not to respond to (default = None)
+; Hosts with IPv4 and IPv6 addresses must have both addresses included to prevent responding.
 ; Example: DontRespondTo = 10.20.1.100-150, 10.20.3.10, fe80::e059:5c8f:a486:a4ea-a4ef, 2001:db8::8a2e:370:7334
 DontRespondTo = 
 

--- a/Responder.conf
+++ b/Responder.conf
@@ -38,7 +38,7 @@ AnalyzeLog = Analyzer-Session.log
 ResponderConfigDump = Config-Responder.log
 
 ; Specific IP Addresses to respond to (default = All)
-; Example: RespondTo = 10.20.1.100-150, 10.20.3.10
+; Example: RespondTo = 10.20.1.100-150, 10.20.3.10, fe80::e059:5c8f:a486:a4ea-a4ef, 2001:db8::8a2e:370:7334
 RespondTo =
 
 ; Specific NBT-NS/LLMNR names to respond to (default = All)
@@ -47,7 +47,7 @@ RespondTo =
 RespondToName = 
 
 ; Specific IP Addresses not to respond to (default = None)
-; Example: DontRespondTo = 10.20.1.100-150, 10.20.3.10
+; Example: DontRespondTo = 10.20.1.100-150, 10.20.3.10, fe80::e059:5c8f:a486:a4ea-a4ef, 2001:db8::8a2e:370:7334
 DontRespondTo = 
 
 ; Specific NBT-NS/LLMNR names not to respond to (default = None)

--- a/poisoners/LLMNR.py
+++ b/poisoners/LLMNR.py
@@ -41,7 +41,7 @@ def IsICMPRedirectPlausible(IP):
 			elif ip[0] == 'nameserver':
 				dnsip.extend(ip[1:])
 		for x in dnsip:
-			if x != "127.0.0.1" and IsOnTheSameSubnet(x,IP) is False:
+			if x != "127.0.0.1" and IsIPv6IP(x) is False and IsOnTheSameSubnet(x,IP) is False:	#Temp fix to ignore IPv6 DNS addresses
 				print(color("[Analyze mode: ICMP] You can ICMP Redirect on this network.", 5))
 				print(color("[Analyze mode: ICMP] This workstation (%s) is not on the same subnet than the DNS server (%s)." % (IP, x), 5))
 				print(color("[Analyze mode: ICMP] Use `python tools/Icmp-Redirect.py` for more details.", 5))

--- a/settings.py
+++ b/settings.py
@@ -52,6 +52,7 @@ class Settings:
 					tab = l.split(':')
 					x = {}
 					i = 0
+					xaddr = ''
 					for byte in tab:
 						if byte == '':
 							byte = '0'
@@ -70,7 +71,10 @@ class Settings:
 										for f in range(x[10], x[11]+1):
 											for g in range(x[12], x[13]+1):
 												for h in range(x[14], x[15]+1):
-													ret.append('%x:%x:%x:%x:%x:%x:%x:%x' % (a, b, c, d, e, f, g, h))
+													xaddr = ('%x:%x:%x:%x:%x:%x:%x:%x' % (a, b, c, d, e, f, g, h))
+													xaddr = re.sub('(^|:)0{1,4}', ':', xaddr, count = 7)#Compresses expanded IPv6 address
+													xaddr = re.sub(':{3,7}', '::', xaddr, count = 7)
+													ret.append(xaddr.upper())
 				else:				
 					tab = l.split('.')
 					x = {}

--- a/settings.py
+++ b/settings.py
@@ -42,25 +42,52 @@ class Settings:
 		return str.upper() == 'ON'
 
 	def ExpandIPRanges(self):
-		def expand_ranges(lst):
+		def expand_ranges(lst):	
 			ret = []
 			for l in lst:
-				tab = l.split('.')
-				x = {}
-				i = 0
-				for byte in tab:
-					if '-' not in byte:
-						x[i] = x[i+1] = int(byte)
-					else:
-						b = byte.split('-')
-						x[i] = int(b[0])
-						x[i+1] = int(b[1])
-					i += 2
-				for a in range(x[0], x[1]+1):
-					for b in range(x[2], x[3]+1):
-						for c in range(x[4], x[5]+1):
-							for d in range(x[6], x[7]+1):
-								ret.append('%d.%d.%d.%d' % (a, b, c, d))
+				if ':' in l: #For IPv6 addresses, similar to the IPv4 version below but hex and pads :'s to expand shortend addresses 
+					while l.count(':') < 7: 
+						pos = l.find('::')
+						l = l[:pos] + ':' + l[pos:]
+					tab = l.split(':')
+					x = {}
+					i = 0
+					for byte in tab:
+						if byte == '':
+							byte = '0'
+						if '-' not in byte:
+							x[i] = x[i+1] = int(byte, base=16)
+						else:
+							b = byte.split('-')
+							x[i] = int(b[0], base=16)
+							x[i+1] = int(b[1], base=16)
+						i += 2
+					for a in range(x[0], x[1]+1):
+						for b in range(x[2], x[3]+1):
+							for c in range(x[4], x[5]+1):
+								for d in range(x[6], x[7]+1):
+									for e in range(x[8], x[9]+1):
+										for f in range(x[10], x[11]+1):
+											for g in range(x[12], x[13]+1):
+												for h in range(x[14], x[15]+1):
+													ret.append('%x:%x:%x:%x:%x:%x:%x:%x' % (a, b, c, d, e, f, g, h))
+				else:				
+					tab = l.split('.')
+					x = {}
+					i = 0
+					for byte in tab:
+						if '-' not in byte:
+							x[i] = x[i+1] = int(byte)
+						else:
+							b = byte.split('-')
+							x[i] = int(b[0])
+							x[i+1] = int(b[1])
+						i += 2
+					for a in range(x[0], x[1]+1):
+						for b in range(x[2], x[3]+1):
+							for c in range(x[4], x[5]+1):
+								for d in range(x[6], x[7]+1):
+									ret.append('%d.%d.%d.%d' % (a, b, c, d))
 			return ret
 
 		self.RespondTo = expand_ranges(self.RespondTo)

--- a/settings.py
+++ b/settings.py
@@ -74,7 +74,7 @@ class Settings:
 													xaddr = ('%x:%x:%x:%x:%x:%x:%x:%x' % (a, b, c, d, e, f, g, h))
 													xaddr = re.sub('(^|:)0{1,4}', ':', xaddr, count = 7)#Compresses expanded IPv6 address
 													xaddr = re.sub(':{3,7}', '::', xaddr, count = 7)
-													ret.append(xaddr.upper())
+													ret.append(xaddr)
 				else:				
 					tab = l.split('.')
 					x = {}


### PR DESCRIPTION
The `ExpandIpRanges` in `settings.py` did not handle IPv6 addresses. Added additional logic that function which:

- Identifies IPv6 vs IPv4 address
- Pads/expands shortened IPv6 addresses to ease iterating a known length
- Iterates through the a provided range in a similar fashion to an IPv4 address
- Shortens the IPv6 address to match with the system will see

Also updated `Responder.conf` in include IPv6 examples for the `RespondTo` and `DontRespondTo` options as wells as including a note that, for systems with both and IPv4 and IPv6 address, BOTH addresses must be included in the `DontRespondTo` option in order to be effective.