### PR TITLE
Fix bug with single byte comparisons in python3

### DIFF
--- a/servers/MSSQL.py
+++ b/servers/MSSQL.py
@@ -168,9 +168,9 @@ class MSSQLBrowser(BaseRequestHandler):
 		if data:
 			if data[0] in b'\x02\x03': # CLNT_BCAST_EX / CLNT_UCAST_EX
 				self.send_response(soc, "MSSQLSERVER")
-			elif data[0] == b'\x04': # CLNT_UCAST_INST
+			elif data[0:1] == b'\x04': # CLNT_UCAST_INST
 				self.send_response(soc, data[1:].rstrip("\x00"))
-			elif data[0] == b'\x0F': # CLNT_UCAST_DAC
+			elif data[0:1] == b'\x0F': # CLNT_UCAST_DAC
 				self.send_dac_response(soc)
 
 	def send_response(self, soc, inst):

--- a/servers/SMB.py
+++ b/servers/SMB.py
@@ -200,7 +200,7 @@ class SMB1(BaseRequestHandler):  # SMB1 & SMB2 Server class, NTLMSSP
 				if not data:
 					break
 
-				if data[0:1] == "\x81":  #session request 139
+				if data[0:1] == b"\x81":  #session request 139
 					Buffer = "\x82\x00\x00\x00"
 					try:
 						self.request.send(Buffer)

--- a/servers/SMB.py
+++ b/servers/SMB.py
@@ -178,7 +178,7 @@ def IsNT4ClearTxt(data, client):
 		WordCount = data[HeadLen]
 		ChainedCmdOffset = data[HeadLen+1]
 
-		if ChainedCmdOffset == "\x75":
+		if ChainedCmdOffset == "\x75" or ChainedCmdOffset == 117:
 			PassLen = struct.unpack('<H',data[HeadLen+15:HeadLen+17])[0]
 
 			if PassLen > 2:

--- a/servers/SMB.py
+++ b/servers/SMB.py
@@ -200,7 +200,7 @@ class SMB1(BaseRequestHandler):  # SMB1 & SMB2 Server class, NTLMSSP
 				if not data:
 					break
 
-				if data[0] == "\x81":  #session request 139
+				if data[0:1] == "\x81":  #session request 139
 					Buffer = "\x82\x00\x00\x00"
 					try:
 						self.request.send(Buffer)
@@ -335,7 +335,7 @@ class SMB1LM(BaseRequestHandler):  # SMB Server class, old version
 			self.request.settimeout(1)
 			data = self.request.recv(1024)
 			Challenge = RandomChallenge()
-			if data[0] == b"\x81":  #session request 139
+			if data[0:1] == b"\x81":  #session request 139
 				Buffer = "\x82\x00\x00\x00"
 				self.request.send(NetworkSendBufferPython2or3(Buffer))
 				data = self.request.recv(1024)

--- a/tools/MultiRelay/RelayMultiCore.py
+++ b/tools/MultiRelay/RelayMultiCore.py
@@ -636,7 +636,7 @@ def MimiKatzRPC(Command, f, host, data, s):
         Output = ExtractRPCCommandOutput(data)[12:]
         while True:
             dataoffset = dataoffset + buffsize
-            if data[64:66] == b"\x05\x00" and data[67] == b"\x02":##Last DCE/RPC Frag
+            if data[64:66] == b"\x05\x00" and data[67:68] == b"\x02":##Last DCE/RPC Frag
                 LastFragLen = struct.unpack('<h', data[61:63])[0]
                 if LastFragLen < 1024:
                     Output += ExtractRPCCommandOutput(data)
@@ -646,7 +646,7 @@ def MimiKatzRPC(Command, f, host, data, s):
                     Output += ExtractRPCCommandOutput(data)
                     break
 
-            if data[64:66] == b"\x05\x00" and data[67] == b"\x03":##First and Last DCE/RPCFrag
+            if data[64:66] == b"\x05\x00" and data[67:68] == b"\x03":##First and Last DCE/RPCFrag
                 data, s, out = SMBDCERPCReadOutput(StructWithLenPython2or3("<i", dataoffset), StructWithLenPython2or3('<h', 4096),f, data, s)
                 Output += ExtractRPCCommandOutput(data)
                 break

--- a/tools/RunFinger.py
+++ b/tools/RunFinger.py
@@ -106,7 +106,7 @@ def ParseNegotiateSMB2Ans(data):
 
 def SMB2SigningMandatory(data):
 	global SMB2signing
-	if data[70] == "\x03":
+	if data[70:71] == b"\x03":
 		SMB2signing = "True"
 	else:
 		SMB2signing = "False"
@@ -201,7 +201,7 @@ def IsDCVuln(t, host):
 #####################
 
 def IsSigningEnabled(data):
-    if data[39] == "\x0f":
+    if data[39:40] == b"\x0f":
         return 'True'
     else:
         return 'False'
@@ -364,7 +364,7 @@ def ConnectAndChoseSMB(host):
 		return False
 
 def handle(data, host):
-	if data[28] == "\x00":
+	if data[28:29] == b"\x00":
 		a =  SMBv2Head()
 		a.calculate()
 		b = SMBv2Negotiate()
@@ -373,7 +373,7 @@ def handle(data, host):
 		buffer0 = longueur(packet0)+packet0
 		return buffer0
 
-	if data[28] == "\x01":
+	if data[28:29] == b"\x01":
 		global Bootime
 		SMB2SigningMandatory(data)
 		Bootime = IsDCVuln(GetBootTime(data[116:124]), host[0])
@@ -385,7 +385,7 @@ def handle(data, host):
 		buffer0 = longueur(packet0)+packet0
 		return buffer0
 
-	if data[28] == "\x02":
+	if data[28:29] == b"\x02":
 		ParseSMBNTLM2Exchange(data, host[0], Bootime, SMB2signing) 
 
 ##################

--- a/tools/SMBFinger/Finger.py
+++ b/tools/SMBFinger/Finger.py
@@ -152,7 +152,7 @@ def color(txt, code = 1, modifier = 0):
     return "\033[%d;3%dm%s\033[0m" % (modifier, code, txt)
 
 def IsSigningEnabled(data):
-    if data[39] == "\x0f":
+    if data[39:40] == b"\x0f":
         return True
     else:
         return False


### PR DESCRIPTION
Fix the bug identified in https://github.com/lgandx/Responder/issues/223 where comparisons with single bytes breaks in python3 in some cases.
For further details see the linked issue.