### PR TITLE
Adding test install workflow for GitHub Actions pipelines

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         host: [ ubuntu-latest, windows-latest, macOS-latest ]
-        python-version: [ "3.6", "3.7", "3.8", "3.9", "3.10", "3.11" ]
+        python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11" ]
     steps:
     - uses: actions/checkout@v3
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,28 @@
+name: Test Responder install
+on: [push, pull_request]
+jobs:
+
+  install_test:
+    runs-on: ${{ matrix.host }}
+    strategy:
+      fail-fast: false
+      matrix:
+        host: [ ubuntu-latest, windows-latest, macOS-latest ]
+        python-version: [ "3.6", "3.7", "3.8", "3.9", "3.10", "3.11" ]
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Setup python-pip
+      run: python -m pip install --upgrade pip
+
+    - name: Install dependencies
+      run: |
+        pip install -r requirements.txt
+
+    - name: Run Responder
+      run: python Responder.py --help


### PR DESCRIPTION
Added a workflow that makes sure responder requirements install, and responder starts properly for all push and pull request triggers.
This is pretty basic right now and adding another workflow checking the code would be nice.
If Responder gets a setup.py / pyproject.toml in the future (as proposed in https://github.com/lgandx/Responder/issues/237) another workflow could also be added to make sure responder installs and runs properly as well.
If you run the pipeline with the current code base, you'll see that it'll fail because of the `netifaces` requirement failing to install.