### PR TITLE
Upgrading `collections` import

### DIFF
--- a/tools/MultiRelay/odict.py
+++ b/tools/MultiRelay/odict.py
@@ -3,7 +3,10 @@ try:
     from UserDict import DictMixin
 except ImportError:
     from collections import UserDict
-    from collections import MutableMapping as DictMixin
+    try:
+        from collections import MutableMapping as DictMixin
+    except ImportError:
+        from collections.abc import MutableMapping as DictMixin
 
 class OrderedDict(dict, DictMixin):
 

--- a/tools/SMBFinger/odict.py
+++ b/tools/SMBFinger/odict.py
@@ -3,7 +3,11 @@ try:
     from UserDict import DictMixin
 except ImportError:
     from collections import UserDict
-    from collections import MutableMapping as DictMixin
+    # https://stackoverflow.com/questions/70870041/cannot-import-name-mutablemapping-from-collections
+    if sys.version_info[:2] >= (3, 8):
+        from collections.abc import MutableMapping
+    else:
+        from collections import MutableMapping
 
 class OrderedDict(dict, DictMixin):
 

--- a/tools/SMBFinger/odict.py
+++ b/tools/SMBFinger/odict.py
@@ -3,11 +3,10 @@ try:
     from UserDict import DictMixin
 except ImportError:
     from collections import UserDict
-    # https://stackoverflow.com/questions/70870041/cannot-import-name-mutablemapping-from-collections
-    if sys.version_info[:2] >= (3, 8):
-        from collections.abc import MutableMapping
-    else:
-        from collections import MutableMapping
+    try:
+        from collections import MutableMapping as DictMixin
+    except ImportError:
+        from collections.abc import MutableMapping as DictMixin
 
 class OrderedDict(dict, DictMixin):
 


### PR DESCRIPTION

This pull request aims at keeping the same import for non-deprecated python versions (up to 3.6) and improve the import for later versions.

```
/Responder/tools/SMBFinger/odict.py:6: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working
  from collections import MutableMapping as DictMixin
```

See https://stackoverflow.com/questions/70870041/cannot-import-name-mutablemapping-from-collections for reference