### PR TITLE
Added a check for Quite_Mode for poisoners in AnalyzeMode

### DIFF
--- a/poisoners/LLMNR.py
+++ b/poisoners/LLMNR.py
@@ -63,14 +63,15 @@ class LLMNR(BaseRequestHandler):  # LLMNR Server class
 			#IPv4
 			if data[2:4] == b'\x00\x00' and LLMNRType:
 				if settings.Config.AnalyzeMode:
-					LineHeader = "[Analyze mode: LLMNR]"
-					print(color("%s Request by %s for %s, ignoring" % (LineHeader, self.client_address[0].replace("::ffff:",""), Name), 2, 1))
-					SavePoisonersToDb({
-							'Poisoner': 'LLMNR', 
-							'SentToIp': self.client_address[0], 
-							'ForName': Name,
-							'AnalyzeMode': '1',
-							})
+					if not settings.Config.Quiet_Mode:
+						LineHeader = "[Analyze mode: LLMNR]"
+						print(color("%s Request by %s for %s, ignoring" % (LineHeader, self.client_address[0].replace("::ffff:",""), Name), 2, 1))
+						SavePoisonersToDb({
+								'Poisoner': 'LLMNR', 
+								'SentToIp': self.client_address[0], 
+								'ForName': Name,
+								'AnalyzeMode': '1',
+								})
 
 				elif LLMNRType == True:  # Poisoning Mode
 					Buffer1 = LLMNR_Ans(Tid=NetworkRecvBufferPython2or3(data[0:2]), QuestionName=Name, AnswerName=Name)

--- a/poisoners/MDNS.py
+++ b/poisoners/MDNS.py
@@ -61,13 +61,14 @@ class MDNS(BaseRequestHandler):
 			return None
 
 		if settings.Config.AnalyzeMode:  # Analyze Mode
-			print(text('[Analyze mode: MDNS] Request by %-15s for %s, ignoring' % (color(self.client_address[0].replace("::ffff:",""), 3), color(Request_Name, 3))))
-			SavePoisonersToDb({
-						'Poisoner': 'MDNS', 
-						'SentToIp': self.client_address[0], 
-						'ForName': Request_Name,
-						'AnalyzeMode': '1',
-					})
+			if not settings.Config.Quiet_Mode:
+				print(text('[Analyze mode: MDNS] Request by %-15s for %s, ignoring' % (color(self.client_address[0].replace("::ffff:",""), 3), color(Request_Name, 3))))
+				SavePoisonersToDb({
+							'Poisoner': 'MDNS', 
+							'SentToIp': self.client_address[0], 
+							'ForName': Request_Name,
+							'AnalyzeMode': '1',
+						})
 		elif MDNSType == True:  # Poisoning Mode
 			Poisoned_Name = Poisoned_MDNS_Name(data)
 			Buffer = MDNS_Ans(AnswerName = Poisoned_Name)

--- a/poisoners/NBTNS.py
+++ b/poisoners/NBTNS.py
@@ -36,13 +36,14 @@ class NBTNS(BaseRequestHandler):
 
 		if data[2:4] == b'\x01\x10':
 			if settings.Config.AnalyzeMode:  # Analyze Mode
-				print(text('[Analyze mode: NBT-NS] Request by %-15s for %s, ignoring' % (color(self.client_address[0].replace("::ffff:",""), 3), color(Name, 3))))
-				SavePoisonersToDb({
-							'Poisoner': 'NBT-NS', 
-							'SentToIp': self.client_address[0], 
-							'ForName': Name,
-							'AnalyzeMode': '1',
-						})
+				if not settings.Config.Quiet_Mode:
+					print(text('[Analyze mode: NBT-NS] Request by %-15s for %s, ignoring' % (color(self.client_address[0].replace("::ffff:",""), 3), color(Name, 3))))
+					SavePoisonersToDb({
+								'Poisoner': 'NBT-NS', 
+								'SentToIp': self.client_address[0], 
+								'ForName': Name,
+								'AnalyzeMode': '1',
+							})
 			else:  # Poisoning Mode
 				Buffer1 = NBT_Ans()
 				Buffer1.calculate(data)


### PR DESCRIPTION
I wanted to make a Responder fully silent by combining Analyze and Quiet modes. It will not do the poisoning, and will not print and save any data from poisoners when `-A` and `-Q` flags are combined together.