### PR TITLE
Fixing soft failure which results in missed SMTP credential interception

### DIFF
--- a/servers/SMTP.py
+++ b/servers/SMTP.py
@@ -65,7 +65,7 @@ class ESMTP(BaseRequestHandler):
 							data = self.request.recv(1024)
 
 							if data:
-								try: Password = b64decode(data)
+								try: Password = b64decode(data).decode('latin-1')
 								except: Password = data
 
 						SaveToDb({


### PR DESCRIPTION
Without this responder silently fails. During debugging I observed [[[can only concatenate str (not "bytes") to str]]] error. Enabling decoding of bytes made the error disappear and credentials properly intercepted (on-screen stdout, logs and to DB).  Thank you for a very useful tool :)