### PR TITLE
Fixed parsing of HTTP basic auth containing colons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,11 @@
+# Python artifacts
+*.pyc
+
 # Responder logs
 *.db
 *.txt
 *.log
 
+# Generated certificates and keys
+certs/*.crt
+certs/*.key

--- a/servers/HTTP.py
+++ b/servers/HTTP.py
@@ -224,8 +224,8 @@ def PacketSequence(data, client, Challenge):
 			'module': 'HTTP', 
 			'type': 'Basic', 
 			'client': client, 
-			'user': ClearText_Auth.decode('latin-1').split(':')[0], 
-			'cleartext': ClearText_Auth.decode('latin-1').split(':')[1], 
+			'user': ClearText_Auth.decode('latin-1').split(':', maxsplit=1)[0], 
+			'cleartext': ClearText_Auth.decode('latin-1').split(':', maxsplit=1)[1], 
 			})
 
 		if settings.Config.Force_WPAD_Auth and WPAD_Custom:


### PR DESCRIPTION
- HTTP basic auth credentials of the form `user:password:with:colons` can now be parsed correctly (fixes #255)
- added a further commit to ignore `.pyc` files and generated certificates