### PR TITLE
Fixed a TypeError in MSSQLBrowser

### DIFF
--- a/servers/MSSQL.py
+++ b/servers/MSSQL.py
@@ -169,7 +169,7 @@ class MSSQLBrowser(BaseRequestHandler):
 			if data[0] in b'\x02\x03': # CLNT_BCAST_EX / CLNT_UCAST_EX
 				self.send_response(soc, "MSSQLSERVER")
 			elif data[0:1] == b'\x04': # CLNT_UCAST_INST
-				self.send_response(soc, data[1:].rstrip("\x00"))
+				self.send_response(soc, data[1:].rstrip(b"\x00"))
 			elif data[0:1] == b'\x0F': # CLNT_UCAST_DAC
 				self.send_dac_response(soc)
 


### PR DESCRIPTION
There was a bytes vs string issue in the `MSSQLBrowser` class which resulted in `TypeError: a bytes-like object is required, not 'str'`.

fixes #251