### PR TITLE
Add options for poisoners

### DIFF
--- a/Responder.conf
+++ b/Responder.conf
@@ -1,24 +1,29 @@
 [Responder Core]
 
-; Servers to start
-SQL = On
-SMB = On
-RDP = On
-Kerberos = On
-FTP = On
-POP = On
-SMTP = On
-IMAP = On
-HTTP = On
-HTTPS = On
-DNS = On
-LDAP = On
-DCERPC = On
-WINRM = On
-SNMP = Off
-MQTT = On
+; Poisoners to start
+MDNS  = On
+LLMNR = On
+NBTNS = On
 
-; Custom challenge. 
+; Servers to start
+SQL      = On
+SMB      = On
+RDP      = On
+Kerberos = On
+FTP      = On
+POP      = On
+SMTP     = On
+IMAP     = On
+HTTP     = On
+HTTPS    = On
+DNS      = On
+LDAP     = On
+DCERPC   = On
+WINRM    = On
+SNMP     = Off
+MQTT     = On
+
+; Custom challenge.
 ; Use "Random" for generating a random challenge for each requests (Default)
 Challenge = Random
 
@@ -65,8 +70,8 @@ AutoIgnoreAfterSuccess = Off
 ; This may break file serving and is useful only for hash capture
 CaptureMultipleCredentials = On
 
-; If set to On, we will write to file all hashes captured from the same host. 
-; In this case, Responder will log from 172.16.0.12 all user hashes: domain\toto, 
+; If set to On, we will write to file all hashes captured from the same host.
+; In this case, Responder will log from 172.16.0.12 all user hashes: domain\toto,
 ; domain\popo, domain\zozo. Recommended value: On, capture everything.
 CaptureMultipleHashFromSameHost = On
 

--- a/Responder.py
+++ b/Responder.py
@@ -294,16 +294,21 @@ def main():
 		if (sys.version_info < (3, 0)):
 			print(color('\n\n[-]', 3, 1) + " Still using python 2? :(")
 		print(color('\n[+]', 2, 1) + " Listening for events...\n")
-			
+
 		threads = []
 
 		# Load (M)DNS, NBNS and LLMNR Poisoners
-		from poisoners.LLMNR import LLMNR
-		from poisoners.NBTNS import NBTNS
-		from poisoners.MDNS import MDNS
-		threads.append(Thread(target=serve_LLMNR_poisoner, args=('', 5355, LLMNR,)))
-		threads.append(Thread(target=serve_MDNS_poisoner,  args=('', 5353, MDNS,)))
-		threads.append(Thread(target=serve_NBTNS_poisoner, args=('', 137,  NBTNS,)))
+		if settings.Config.LLMNR_On_Off:
+		    from poisoners.LLMNR import LLMNR
+		    threads.append(Thread(target=serve_LLMNR_poisoner, args=('', 5355, LLMNR,)))
+
+		if settings.Config.NBTNS_On_Off:
+		    from poisoners.NBTNS import NBTNS
+		    threads.append(Thread(target=serve_NBTNS_poisoner, args=('', 137,  NBTNS,)))
+
+		if settings.Config.MDNS_On_Off:
+		    from poisoners.MDNS import MDNS
+		    threads.append(Thread(target=serve_MDNS_poisoner,  args=('', 5353, MDNS,)))
 
 		#// Vintage Responder BOWSER module, now disabled by default. 
 		#// Generate to much noise & easily detectable on the network when in analyze mode.

--- a/settings.py
+++ b/settings.py
@@ -114,7 +114,12 @@ class Settings:
 		# Config parsing
 		config = ConfigParser.ConfigParser()
 		config.read(os.path.join(self.ResponderPATH, 'Responder.conf'))
-		
+
+        # Poisoners
+		self.LLMNR_On_Off    = self.toBool(config.get('Responder Core', 'LLMNR'))
+		self.NBNS_On_Off     = self.toBool(config.get('Responder Core', 'NBTNS'))
+		self.MDNS_On_Off     = self.toBool(config.get('Responder Core', 'MDNS'))
+
 		# Servers
 		self.HTTP_On_Off     = self.toBool(config.get('Responder Core', 'HTTP'))
 		self.SSL_On_Off      = self.toBool(config.get('Responder Core', 'HTTPS'))


### PR DESCRIPTION
I recently had a coworker ask how they could disable NBTNS poisoning specifically, and since the only way to do that was to modify the code, I thought, why not add in the option to do it in the config?

Specifically:

```ini
[Responder Core]

; Poisoners to start
MDNS  = On
LLMNR = On
NBTNS = On

; Servers to start
SQL      = On
... etc
```