### PR TITLE
DHCP poisoner: refactor FindIP

### DIFF
--- a/poisoners/DHCP.py
+++ b/poisoners/DHCP.py
@@ -239,9 +239,12 @@ def ParseSrcDSTAddr(data):
     return SrcIP, SrcPort, DstIP, DstPort
 
 def FindIP(data):
-    data = data.decode('latin-1')
-    IP = ''.join(re.findall(r'(?<=\x32\x04)[^EOF]*', data))
-    return ''.join(IP[0:4]).encode('latin-1')
+    IPPos = data.find(b"\x32\x04") + 2
+    if IPPos == -1 or IPPos + 4 >= len(data):
+        return None
+    else:
+        IP = data[IPPos:IPPos+4]
+        return IP
 
 def ParseDHCPCode(data, ClientIP,DHCP_DNS):
     global DHCPClient


### PR DESCRIPTION
Hey, thanks for the great tool!

Recently I ran into #181 and #304 during DHCP poisoning.
As far as I understand the code, it currently breaks when the IP address contains an `E`, `O` or `F` since it prematurely terminates the IP address' bytes. (Instead of checking for the end-of-input, as I'm assuming was the intent)

This commit should resolve those issues since it always takes the four bytes required for an IPv4 address.
It also operates directly on the bytes and avoids an additional encoding/decoding round-trip.