### PR TITLE
Disabled printing of ignored LLMNR, NBT-NS and MDNS messages in Analyze Mode with Quiet Mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Python artifacts
 *.pyc
+.venv/
 
 # Responder logs
 *.db
@@ -9,3 +10,6 @@
 # Generated certificates and keys
 certs/*.crt
 certs/*.key
+
+# IDE
+.idea/

--- a/poisoners/LLMNR.py
+++ b/poisoners/LLMNR.py
@@ -71,7 +71,9 @@ class LLMNR(BaseRequestHandler):  # LLMNR Server class
 			if data[2:4] == b'\x00\x00' and LLMNRType:
 				if settings.Config.AnalyzeMode:
 					LineHeader = "[Analyze mode: LLMNR]"
-					print(color("%s Request by %s for %s, ignoring" % (LineHeader, self.client_address[0].replace("::ffff:",""), Name), 2, 1))
+					# Don't print if in Quiet Mode
+					if not settings.Config.Quite_Mode:
+						print(color("%s Request by %s for %s, ignoring" % (LineHeader, self.client_address[0].replace("::ffff:",""), Name), 2, 1))
 					SavePoisonersToDb({
 							'Poisoner': 'LLMNR', 
 							'SentToIp': self.client_address[0], 

--- a/poisoners/MDNS.py
+++ b/poisoners/MDNS.py
@@ -64,7 +64,9 @@ class MDNS(BaseRequestHandler):
 				return None
 
 			if settings.Config.AnalyzeMode:  # Analyze Mode
-				print(text('[Analyze mode: MDNS] Request by %-15s for %s, ignoring' % (color(self.client_address[0].replace("::ffff:",""), 3), color(Request_Name, 3))))
+				# Don't print if in Quiet Mode
+				if not settings.Config.Quite_Mode:
+					print(text('[Analyze mode: MDNS] Request by %-15s for %s, ignoring' % (color(self.client_address[0].replace("::ffff:",""), 3), color(Request_Name, 3))))
 				SavePoisonersToDb({
 						'Poisoner': 'MDNS', 
 						'SentToIp': self.client_address[0], 

--- a/poisoners/NBTNS.py
+++ b/poisoners/NBTNS.py
@@ -36,7 +36,9 @@ class NBTNS(BaseRequestHandler):
 
 			if data[2:4] == b'\x01\x10':
 				if settings.Config.AnalyzeMode:  # Analyze Mode
-					print(text('[Analyze mode: NBT-NS] Request by %-15s for %s, ignoring' % (color(self.client_address[0].replace("::ffff:",""), 3), color(Name, 3))))
+					# Don't print if in Quiet Mode
+					if not settings.Config.Quite_Mode:
+						print(text('[Analyze mode: NBT-NS] Request by %-15s for %s, ignoring' % (color(self.client_address[0].replace("::ffff:",""), 3), color(Name, 3))))
 					SavePoisonersToDb({
 							'Poisoner': 'NBT-NS', 
 							'SentToIp': self.client_address[0], 


### PR DESCRIPTION
Added a check for quiet mode used with analyze mode. The Responder will not print any messages of "Ignored requests" if the quiet mode is used. It makes it possible to suppress useless output if I wanted to. 