### PR TITLE
[servers/LDAP] Handle a different format for searchRequest operation

### DIFF
--- a/servers/LDAP.py
+++ b/servers/LDAP.py
@@ -59,8 +59,8 @@ def ParseCLDAPNetlogon(data):
 		pass
 
 
-def ParseSearch(data):
-	TID = data[8:9].decode('latin-1')
+def ParseSearch(data, message_id):
+	TID = message_id.decode('latin-1')
 	if re.search(b'Netlogon', data):
 		NbtName = settings.Config.MachineName
 		TID = NetworkRecvBufferPython2or3(data[8:10])
@@ -172,7 +172,7 @@ def ParseCLDAPPacket(data, client, Challenge):
 				return Buffer
 		
 		elif Operation == b'\x63':
-			Buffer = ParseSearch(data)
+			Buffer = ParseSearch(data, data[8:9])
 			print(text('[CLDAP] Sent CLDAP pong to %s.'% client.replace("::ffff:","")))
 			return Buffer
 
@@ -194,6 +194,10 @@ def ParseCLDAPPacket(data, client, Challenge):
 			'cleartext': PassStr,
 			'fullhash': UserString+':'+PassStr,
 			})
+
+	elif data[5:6] == b'\x63':
+		Buffer = ParseSearch(data, data[4:5])
+		return Buffer
 
 
 def ParseLDAPPacket(data, client, Challenge):
@@ -226,7 +230,7 @@ def ParseLDAPPacket(data, client, Challenge):
 				return Buffer
 		
 		elif Operation == b'\x63':
-			Buffer = ParseSearch(data)
+			Buffer = ParseSearch(data, data[8:9])
 			return Buffer
 
 		elif settings.Config.Verbose:
@@ -247,6 +251,11 @@ def ParseLDAPPacket(data, client, Challenge):
 			'cleartext': PassStr,
 			'fullhash': UserString+':'+PassStr,
 			})
+
+	elif data[5:6] == b'\x63':
+		Buffer = ParseSearch(data, data[4:5])
+		return Buffer
+
 
 class LDAP(BaseRequestHandler):
 	def handle(self):


### PR DESCRIPTION
Hi!

I've got here a Toshiba TopAccess printer which, prior to sending its simple bind authentication, performs a search request for `supportedSASLMechanisms` using a different binary format than the one currently supported by Responder. Here's a b64-encoded PCAP of the request (GitHub doesn't support uploading .pcap files):
```
1MOyoQIABAAAAAAAAAAAAAAABAABAAAAydfwaPv5CQCCAAAAggAAAAECAwQFBv/+/fz7+ggARQAAdKE6QAA/BkiMfwAAAX8AAAKlZgGFegFxOk2GvcCAGADl0EQAAAEBCAolANAEQ4GHqzA+AgEBYzkEAAoBAAoBAAIBAAIBAAEBAIcLb2JqZWN0Y2xhc3MwGQQXc3VwcG9ydGVkU0FTTE1lY2hhbmlzbXM=
```

This PR modifies the LDAP server to handle this format and respond with the expected data, letting the printer finally send its creds. Here's a PCAP of the complete flow, after applying this PR (creds are anonymised of course :slightly_smiling_face:):
```
1MOyoQIABAAAAAAAAAAAAAAABAABAAAA/dvwaBjsAQCCAAAAggAAAAECAwQFBv/+/fz7+ggARQAAdN8rQAA/BgqbfwAAAn8AAAGlcgGFbrTmK0zi59yAGADlaugAAAEBCAolETkHQ5HwuzA+AgEBYzkEAAoBAAoBAAIBAAIBAAEBAIcLb2JqZWN0Y2xhc3MwGQQXc3VwcG9ydGVkU0FTTE1lY2hhbmlzbXP92/BoovABAL4AAAC+AAAA//79/Pv6AQIDBAUGCABFAACw4BpAAEAGCHB/AAABfwAAAgGFpXJM4ufcbrTma4AYAEBSYAAAAQEICkOR8MAlETkHMIQAAABgAgEBZIQAAABXBAAwhAAAAE8whAAAAEkEF3N1cHBvcnRlZFNBU0xNZWNoYW5pc21zMYQAAAAqBAZHU1NBUEkECkdTUy1TUE5FR08ECEVYVEVSTkFMBApESUdFU1QtTUQ1MIQAAAAQAgEBZYQAAAAHCgEABAAEAP3b8GiXaQMAaAAAAGgAAAABAgMEBQb//v38+/oIAEUAAFrfLUAAPwYKs38AAAJ/AAABpXIBhW605mtM4uhYgBgA5ZQSAAABAQgKJRE5XkOR8MAwJAIBAmAfAgEDBAtYWFhcWFhYWFhYWIANWFhYWFhYWFhYWFhYWA==
```

Note: I applied the same change to the CLDAP server, though I don't know if it's relevant and couldn't test for it.

Thanks!