### PR TITLE
Fix pyproject.toml license metadata incompatibility with PDM backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,7 @@ dependencies = ["aioquic", "netifaces>=0.10.4"]
 classifiers = [
     "Operating System :: MacOS",
     "Operating System :: POSIX :: Linux",
-    "Topic :: Security",
-    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)"
+    "Topic :: Security"
 ]
 
 [project.urls]


### PR DESCRIPTION
## **Description**

This PR resolves a build failure when installing **Responder** using modern packaging tools such as **PDM** or **uv**.

### **Problem**

Recent versions of `pdm-backend` enforce stricter validation of project metadata according to [PEP 621](https://peps.python.org/pep-0621/).  
The current `pyproject.toml` specifies both:

```toml
license = "GPL-3.0-only"
```

and a license classifier:

```toml
"License :: OSI Approved :: GNU General Public License v3 (GPLv3)"
```

These two declarations are **mutually exclusive** under PDM’s validation rules and cause the following error during build:

```
pdm.backend.exceptions.ValidationError: project.license: Setting "project.license" to an SPDX license expression is not compatible with 'License ::' classifiers
```

### **Changes**

- Removed the redundant `License :: OSI Approved :: GNU General Public License v3 (GPLv3)` classifier.  
- Kept the SPDX-style field `license = "GPL-3.0-only"` for compatibility with PDM and other PEP 621-compliant backends.  
- No functional or behavioral changes to the project code.

### **Result**

After this change, **Responder** builds and installs successfully using:

```bash
uv tool install git+https://github.com/lgandx/Responder
```

and other PDM-compliant tools.