### PR TITLE
Update classifiers in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,7 @@ dependencies = ["aioquic", "netifaces>=0.10.4"]
 classifiers = [
     "Operating System :: MacOS",
     "Operating System :: POSIX :: Linux",
-    "Topic :: Security",
-    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)"
+    "Topic :: Security"
 ]
 
 [project.urls]


### PR DESCRIPTION
Removed GPLv3 license classifier from project metadata because it caused an error when installing with pipx.