### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ classifiers = [
     "Operating System :: MacOS",
     "Operating System :: POSIX :: Linux",
     "Topic :: Security",
-    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)"
 ]
 
 [project.urls]


### PR DESCRIPTION
Resolves Error:

pdm.backend.exceptions.ValidationError: project.license: Setting "project.license" to an SPDX license expression is not compatible with 'License ::' classifiers

Issue Details:
As outlined in PEP 639. Modern build backends like pdm.backend now enforce a new standard for license declaration, moving away from the older system of using "License :: ..." Trove classifiers. Key points of the change:
Shift to SPDX License Expressions: PEP 639 introduces the use of SPDX (Software Package Data Exchange) license expression syntax for declaring package licenses. This provides a more precise and standardized way to specify licenses compared to the less specific Trove classifiers. License-Expression Field: The core metadata version 2.4, as defined by PEP 639, requires a new License-Expression field in the package metadata (e.g., in pyproject.toml). This field must contain a valid SPDX expression. Deprecation of License Classifiers: The use of "License :: ..." Trove classifiers is deprecated. If a package includes a License-Expression field, build tools and publishing tools will now raise an error if license classifiers are also present. Recommended Approach: The modern and recommended way to declare a license is to use the SPDX string in the License-Expression field and remove any corresponding "License :: ..." Trove classifiers. License-File Field: Additionally, a License-File field may be used to specify paths to license files included in the distribution. In summary: If you are using a modern build backend like pdm.backend and specifying your license using an SPDX string (e.g., in the license field of pyproject.toml), you must remove any redundant "License :: ..." Trove classifiers to avoid errors during the build or publishing process. The SPDX string and the License-Expression field are the preferred and enforced method for license declaration.

Results
License-Files = ["LICENSE"] makes License :: ... obsolete and throws errors in installation of pdm-backend,