### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ This version includes:
 
 ```bash
 sudo apt-get update
-sudo apt-get install python3 python3-pip python3-netifaces
+sudo apt-get install python3 python3-pip python3-netifaces python3-dev
 ```
 
 ### Install Responder


### PR DESCRIPTION
Added python3-dev development headers, which are often times not installed automatically

pip needs to compile C code for netifaces, which requires the Python development headers