### PR TITLE
Update SASL hash format to align with hashcat module expected format

### DIFF
--- a/servers/LDAP.py
+++ b/servers/LDAP.py
@@ -483,13 +483,13 @@ def ParseDIGESTMD5(data, client, Challenge):
 			realm = realm_match.group(1) if realm_match else ''
 			nonce = nonce_match.group(1) if nonce_match else ''
 			cnonce = cnonce_match.group(1) if cnonce_match else ''
-			nc = nc_match.group(1) if nc_match else ''
+			nc = nc_match.group(1) if nc_match else '00000001'
 			qop = qop_match.group(1) if qop_match else ''
 			uri = uri_match.group(1) if uri_match else ''
 			response = response_match.group(1)
 			
 			# Format for hashcat/john
-			hash_string = '%s:$sasl$DIGEST-MD5$%s$%s$%s$%s$%s$%s$%s' % (username, realm, nonce, cnonce, nc, qop, uri, response)
+			hash_string = '%s:$sasl$DIGEST-MD5$%s$%s$%s$%s$%s$%s$%s$%s' % (username, realm, username, nonce, cnonce, nc, qop, uri, response)
 			
 			SaveToDb({
 				'module': 'LDAP',

--- a/servers/SMTP.py
+++ b/servers/SMTP.py
@@ -290,14 +290,14 @@ class ESMTP(BaseRequestHandler):
 			realm = realm_match.group(1) if realm_match else ''
 			resp_nonce = nonce_match.group(1) if nonce_match else ''
 			cnonce = cnonce_match.group(1) if cnonce_match else ''
-			nc = nc_match.group(1) if nc_match else ''
+			nc = nc_match.group(1) if nc_match else '00000001'
 			qop = qop_match.group(1) if qop_match else ''
 			uri = uri_match.group(1) if uri_match else ''
 			resp_hash = response_match.group(1)
 			
 			# Format for hashcat/john
-			hash_string = "%s:$sasl$DIGEST-MD5$%s$%s$%s$%s$%s$%s$%s" % (
-				username, realm, nonce, cnonce, nc, qop, uri, resp_hash
+			hash_string = "%s:$sasl$DIGEST-MD5$%s$%s$%s$%s$%s$%s$%s$%s" % (
+				username, realm, username, resp_nonce, cnonce, nc, qop, uri, resp_hash
 			)
 			
 			SaveToDb({


### PR DESCRIPTION
There are 2 minor changes needed to the SASL DIGEST-MD5 format to make them usable in hashcat. The username is required for the first MD5 computation MD5(username:realm:password), but was only present as the user:hash prefix and thus not included in the data fields hashcat parses. Additionally, when a client omits the nonce count, Responder wrote an empty value to that field. The nc is also part of the response computation MD5(HA1:nonce:nc:cnonce:qop:HA2), so an empty value makes the hash uncrackable. RFC 2831 specifies 00000001 as the default for the first auth attempt so in the module/kernel we assume empty means 00000001 but making it an explicit field makes this cleaner for both sides.

Format change:
`username:$sasl$DIGEST-MD5$realm$nonce$cnonce$nc$qop$uri$response`
->
`username:$sasl$DIGEST-MD5$realm$username$nonce$cnonce$nc$qop$uri$response`

There is a corresponding PR open for adding this mode and the APOP hash mode to hashcat here: https://github.com/hashcat/hashcat/pull/4706
